### PR TITLE
fix: replace Hedera RPC with mirror node call for fetching account balance

### DIFF
--- a/libs/coin-modules/coin-hedera/src/api/mirror.ts
+++ b/libs/coin-modules/coin-hedera/src/api/mirror.ts
@@ -4,9 +4,11 @@ import { Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { getEnv } from "@ledgerhq/live-env";
 import { encodeOperationId } from "@ledgerhq/coin-framework/operation";
-import { getAccountBalance } from "./network";
 import { base64ToUrlSafeBase64 } from "../bridge/utils";
 import { HederaOperationExtra } from "../types";
+import { HederaMirrorAccount } from "./types";
+import { HederaAddAccountError } from "../errors";
+import { LedgerAPI4xx } from "@ledgerhq/errors";
 
 const getMirrorApiUrl = (): string => getEnv("API_HEDERA_MIRROR");
 
@@ -17,32 +19,33 @@ const fetch = (path: string) => {
   });
 };
 
-interface HederaMirrorAccount {
-  accountId: AccountId;
-  balance: BigNumber;
-}
-
 export async function getAccountsForPublicKey(publicKey: string): Promise<HederaMirrorAccount[]> {
   let r;
   try {
-    r = await fetch(`/api/v1/accounts?account.publicKey=${publicKey}&balance=false`);
+    r = await fetch(`/api/v1/accounts?account.publicKey=${publicKey}&balance=true&limit=100`);
   } catch (e: any) {
     if (e.name === "LedgerAPI4xx") return [];
     throw e;
   }
-  const rawAccounts = r.data.accounts;
-  const accounts: HederaMirrorAccount[] = [];
 
-  for (const raw of rawAccounts) {
-    const accountBalance = await getAccountBalance(raw.account);
-
-    accounts.push({
-      accountId: AccountId.fromString(raw.account),
-      balance: accountBalance.balance,
-    });
-  }
+  const accounts = r.data.accounts as HederaMirrorAccount[];
 
   return accounts;
+}
+
+export async function getAccount(address: string): Promise<HederaMirrorAccount> {
+  try {
+    const res = await fetch(`/api/v1/accounts/${address}`);
+    const account = res.data as HederaMirrorAccount;
+
+    return account;
+  } catch (error) {
+    if (error instanceof LedgerAPI4xx && "status" in error && error.status === 404) {
+      throw new HederaAddAccountError();
+    }
+
+    throw error;
+  }
 }
 
 interface HederaMirrorTransfer {

--- a/libs/coin-modules/coin-hedera/src/api/network.ts
+++ b/libs/coin-modules/coin-hedera/src/api/network.ts
@@ -1,16 +1,7 @@
 import BigNumber from "bignumber.js";
 import type { Transaction as HederaTransaction, TransactionResponse } from "@hashgraph/sdk";
-import {
-  Client,
-  TransferTransaction,
-  Hbar,
-  AccountId,
-  TransactionId,
-  AccountBalanceQuery,
-  HbarUnit,
-} from "@hashgraph/sdk";
+import { Client, TransferTransaction, Hbar, AccountId, TransactionId } from "@hashgraph/sdk";
 import { Account } from "@ledgerhq/types-live";
-import { HederaAddAccountError } from "../errors";
 import { Transaction } from "../types";
 
 export function broadcastTransaction(transaction: HederaTransaction): Promise<TransactionResponse> {
@@ -45,26 +36,7 @@ export interface AccountBalance {
   balance: BigNumber;
 }
 
-export async function getAccountBalance(address: string): Promise<AccountBalance> {
-  const accountId = AccountId.fromString(address);
-  let accountBalance;
-
-  try {
-    accountBalance = await new AccountBalanceQuery({
-      accountId,
-    }).execute(getBalanceClient());
-  } catch {
-    throw new HederaAddAccountError();
-  }
-
-  return {
-    balance: accountBalance.hbars.to(HbarUnit.Tinybar),
-  };
-}
-
 let _hederaClient: Client | null = null;
-
-let _hederaBalanceClient: Client | null = null;
 
 function getClient(): Client {
   _hederaClient ??= Client.forMainnet().setMaxNodesPerTransaction(1);
@@ -72,10 +44,4 @@ function getClient(): Client {
   //_hederaClient.setNetwork({ mainnet: "https://hedera.coin.ledger.com" });
 
   return _hederaClient;
-}
-
-function getBalanceClient(): Client {
-  _hederaBalanceClient ??= Client.forMainnet();
-
-  return _hederaBalanceClient;
 }

--- a/libs/coin-modules/coin-hedera/src/api/types.ts
+++ b/libs/coin-modules/coin-hedera/src/api/types.ts
@@ -1,0 +1,12 @@
+export interface HederaMirrorAccount {
+  account: string;
+  max_automatic_token_associations: number;
+  balance: {
+    balance: number;
+    timestamp: string;
+    tokens: {
+      token_id: string;
+      balance: number;
+    }[];
+  };
+}

--- a/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
@@ -6,14 +6,13 @@ import {
 } from "@ledgerhq/coin-framework/derivation";
 import { BigNumber } from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
-import { getAccountsForPublicKey, getOperationsForAccount } from "../api/mirror";
+import { getAccount, getAccountsForPublicKey, getOperationsForAccount } from "../api/mirror";
 import {
   GetAccountShape,
   IterateResultBuilder,
   mergeOps,
 } from "@ledgerhq/coin-framework/bridge/jsHelpers";
 import { encodeAccountId } from "@ledgerhq/coin-framework/account";
-import { getAccountBalance } from "../api/network";
 
 export const getAccountShape: GetAccountShape<Account> = async (
   info: any,
@@ -31,7 +30,8 @@ export const getAccountShape: GetAccountShape<Account> = async (
   });
 
   // get current account balance
-  const accountBalance = await getAccountBalance(address);
+  const mirrorAccount = await getAccount(address);
+  const accountBalance = new BigNumber(mirrorAccount.balance.balance);
 
   // grab latest operation's consensus timestamp for incremental sync
   const oldOperations = initialAccount?.operations ?? [];
@@ -50,8 +50,8 @@ export const getAccountShape: GetAccountShape<Account> = async (
   return {
     id: liveAccountId,
     freshAddress: address,
-    balance: accountBalance.balance,
-    spendableBalance: accountBalance.balance,
+    balance: accountBalance,
+    spendableBalance: accountBalance,
     operations,
     // NOTE: there are no "blocks" in hedera
     // Set a value just so that operations are considered confirmed according to isConfirmedOperation
@@ -60,8 +60,8 @@ export const getAccountShape: GetAccountShape<Account> = async (
 };
 
 export const buildIterateResult: IterateResultBuilder = async ({ result: rootResult }) => {
-  const accounts = await getAccountsForPublicKey(rootResult.publicKey);
-  const addresses = accounts.map(a => a.accountId.toString());
+  const mirrorAccounts = await getAccountsForPublicKey(rootResult.publicKey);
+  const addresses = mirrorAccounts.map(a => a.account);
 
   return async ({ currency, derivationMode, index }) => {
     const derivationScheme = getDerivationScheme({


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

LL tries to fetch the account balance from https://grpc-web.myhbarwallet.com/proto.CryptoService/cryptoGetBalance (via @hashgraph/sdk), but it ends up spamming retries and eventually crashes the whole add account flow. This PR switches that logic over to use a mirror node call to fetch the account balance instead.

Related announcement:
https://x.com/hedera_devs/status/1920929258081280440

Current behavior:

<img width="588" height="396" alt="edera 2" src="https://github.com/user-attachments/assets/9e74b7ca-37a9-4e22-908b-116c7c25fe37" />
<img width="855" height="835" alt="Meces  Cotro Брия" src="https://github.com/user-attachments/assets/33160a06-0a8d-46d9-b2b3-0f689ab35580" />


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
