### PR TITLE
fix(sodax): coin sodax sendmax and failed operation

### DIFF
--- a/.changeset/coin-icon-sendmax-and-failed-operation.md
+++ b/.changeset/coin-icon-sendmax-and-failed-operation.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-icon": patch
+---
+
+Estimate send-max fees against a nominal amount, and treat a step limit of zero as a failed estimate. The node returns a step estimate of zero for a transfer of the whole balance, which put a step limit of zero into the transaction. The node then dropped the transaction.
+
+Report only the fee as the operation value for a reverted transfer. A reverted transaction moves no value; the chain takes the step cost.

--- a/libs/coin-modules/coin-icon/src/__test__/api/index.unit.test.ts
+++ b/libs/coin-modules/coin-icon/src/__test__/api/index.unit.test.ts
@@ -152,5 +152,86 @@ describe("ICON API", () => {
         url: `testnet-url/transactions/address/${addr}?address=${addr}&skip=${skip + 2}&limit=${2}`,
       });
     });
+
+    it("should report only the fee as value for a failed send", async () => {
+      const accountId = "accountId";
+      const addr = "hx123";
+      const skip = 0;
+      const network = { id: "icon" } as CryptoCurrency;
+      const maxLength = 10;
+      mockLimit = 10;
+
+      const tx = {
+        hash: "tx1",
+        from_address: addr,
+        to_address: "hx456",
+        transaction_fee: "10150000000000000",
+        block_number: 12345,
+        block_timestamp: 1609459200000,
+        status: "0x0",
+        value: "1000000000000000000",
+      } as IconTransactionType;
+      querystringMock.mockReturnValue("address=hx123&skip=0&limit=10");
+      networkMock.mockResolvedValue({ data: [tx] });
+
+      const [op] = await fetchOperationList(accountId, addr, skip, network, maxLength);
+
+      expect(op.hasFailed).toBe(true);
+      expect(op.value.toFixed()).toBe("10150000000000000");
+    });
+
+    it("should report zero value for a failed receive", async () => {
+      const accountId = "accountId";
+      const addr = "hx123";
+      const skip = 0;
+      const network = { id: "icon" } as CryptoCurrency;
+      const maxLength = 10;
+      mockLimit = 10;
+
+      const tx = {
+        hash: "tx1",
+        from_address: "hx456",
+        to_address: addr,
+        transaction_fee: "10150000000000000",
+        block_number: 12345,
+        block_timestamp: 1609459200000,
+        status: "0x0",
+        value: "1000000000000000000",
+      } as IconTransactionType;
+      querystringMock.mockReturnValue("address=hx123&skip=0&limit=10");
+      networkMock.mockResolvedValue({ data: [tx] });
+
+      const [op] = await fetchOperationList(accountId, addr, skip, network, maxLength);
+
+      expect(op.hasFailed).toBe(true);
+      expect(op.value.toFixed()).toBe("0");
+    });
+
+    it("should report value plus fee for a successful send", async () => {
+      const accountId = "accountId";
+      const addr = "hx123";
+      const skip = 0;
+      const network = { id: "icon" } as CryptoCurrency;
+      const maxLength = 10;
+      mockLimit = 10;
+
+      const tx = {
+        hash: "tx1",
+        from_address: addr,
+        to_address: "hx456",
+        transaction_fee: "10150000000000000",
+        block_number: 12345,
+        block_timestamp: 1609459200000,
+        status: "0x1",
+        value: "1000000000000000000",
+      } as IconTransactionType;
+      querystringMock.mockReturnValue("address=hx123&skip=0&limit=10");
+      networkMock.mockResolvedValue({ data: [tx] });
+
+      const [op] = await fetchOperationList(accountId, addr, skip, network, maxLength);
+
+      expect(op.hasFailed).toBe(false);
+      expect(op.value.toFixed()).toBe("1010150000000000000");
+    });
   });
 });

--- a/libs/coin-modules/coin-icon/src/__test__/unit/buildTransaction.test.ts
+++ b/libs/coin-modules/coin-icon/src/__test__/unit/buildTransaction.test.ts
@@ -63,6 +63,13 @@ describe("buildTransaction", () => {
     expect(result.unsigned).toBe("mocked-transaction");
   });
 
+  it("should omit stepLimit when it is zero", async () => {
+    const stepLimit = new BigNumber(0);
+    await buildTransaction(account, transaction, stepLimit);
+
+    expect(mockStepLimit).not.toHaveBeenCalled();
+  });
+
   it("should throw an error for unsupported transaction mode", async () => {
     const invalidTransaction: Transaction = {
       ...transaction,

--- a/libs/coin-modules/coin-icon/src/__test__/unit/getFeesForTransaction.unit.test.ts
+++ b/libs/coin-modules/coin-icon/src/__test__/unit/getFeesForTransaction.unit.test.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from "bignumber.js";
 import { getFees, getStepPrice } from "../../api/node";
 import { buildTransaction } from "../../buildTransaction";
+import { DEFAULT_STEP_LIMIT } from "../../constants";
 import getEstimatedFees from "../../getFeesForTransaction";
 import * as logic from "../../logic";
 import { IconAccount } from "../../types";
@@ -45,7 +46,7 @@ describe("getEstimatedFees", () => {
     expect(transaction.stepLimit).toEqual(stepLimit);
   });
 
-  it("should return FEES_SAFETY_BUFFER if an error occurs", async () => {
+  it("should return FEES_SAFETY_BUFFER if getStepPrice rejects", async () => {
     const account = {
       currency: { id: "icon" },
       spendableBalance: new BigNumber(1000),
@@ -62,10 +63,70 @@ describe("getEstimatedFees", () => {
     mockedLogic.calculateAmount.mockReturnValue(new BigNumber(100));
     // @ts-expect-error type
     mockedLogic.FEES_SAFETY_BUFFER = new BigNumber(100);
-    (buildTransaction as jest.Mock).mockRejectedValue(new Error("Error"));
-    // Mock getFees and getStepPrice if necessary, but they won't be called in this test case
+    (getStepPrice as jest.Mock).mockRejectedValue(new Error("Error"));
+    (buildTransaction as jest.Mock).mockResolvedValue({ unsigned: {} });
 
     const estimatedFees = await getEstimatedFees({ account, transaction });
     expect(estimatedFees.isEqualTo(new BigNumber(100))).toBe(true);
+  });
+
+  it("should fall back to DEFAULT_STEP_LIMIT if the estimated step limit is zero", async () => {
+    const account: IconAccount = {
+      currency: { id: "icon" },
+      spendableBalance: new BigNumber(1000),
+      pendingOperations: [],
+      iconResources: { nonce: 1 },
+    } as any;
+
+    const transaction = {
+      amount: new BigNumber(100),
+      recipient: "recipient-address",
+      fees: new BigNumber(10),
+    } as any;
+
+    const stepPrice = new BigNumber(10);
+
+    mockedLogic.calculateAmount.mockReturnValue(new BigNumber(100));
+    (buildTransaction as jest.Mock).mockResolvedValue({ unsigned: {} });
+    (getFees as jest.Mock).mockResolvedValue(new BigNumber(0));
+    (getStepPrice as jest.Mock).mockResolvedValue(stepPrice);
+
+    const estimatedFees = await getEstimatedFees({ account, transaction });
+    expect(estimatedFees.isEqualTo(new BigNumber(DEFAULT_STEP_LIMIT).multipliedBy(stepPrice))).toBe(
+      true,
+    );
+    expect(transaction.stepLimit).toEqual(new BigNumber(DEFAULT_STEP_LIMIT));
+  });
+
+  it("should estimate against a nominal amount when useAllAmount is set", async () => {
+    const account: IconAccount = {
+      currency: { id: "icon" },
+      spendableBalance: new BigNumber(1000),
+      pendingOperations: [],
+      iconResources: { nonce: 1 },
+    } as any;
+
+    const transaction = {
+      amount: new BigNumber(1000),
+      recipient: "recipient-address",
+      fees: new BigNumber(10),
+      useAllAmount: true,
+    } as any;
+
+    const stepLimit = new BigNumber(100000);
+    const stepPrice = new BigNumber(10);
+
+    (buildTransaction as jest.Mock).mockResolvedValue({ unsigned: {} });
+    (getFees as jest.Mock).mockResolvedValue(stepLimit);
+    (getStepPrice as jest.Mock).mockResolvedValue(stepPrice);
+
+    const calledAmountsBefore = mockedLogic.calculateAmount.mock.calls.length;
+
+    await getEstimatedFees({ account, transaction });
+
+    expect(mockedLogic.calculateAmount.mock.calls.length).toBe(calledAmountsBefore);
+    const buildTransactionCalls = (buildTransaction as jest.Mock).mock.calls;
+    const [, calledTransaction] = buildTransactionCalls[buildTransactionCalls.length - 1];
+    expect(calledTransaction.amount.isEqualTo(new BigNumber(1))).toBe(true);
   });
 });

--- a/libs/coin-modules/coin-icon/src/api/index.ts
+++ b/libs/coin-modules/coin-icon/src/api/index.ts
@@ -68,14 +68,29 @@ function getOperationType(transaction: IconTransactionType, addr: string): Opera
 }
 
 /**
+ * Returns true if the transaction was reverted on-chain
+ */
+function hasTransactionFailed(transaction: IconTransactionType): boolean {
+  return transaction.status !== "0x1";
+}
+
+/**
  * Map transaction to a correct Operation Value (affecting account balance)
+ *
+ * A reverted transaction moves no value; only the step cost is charged.
  */
 function getOperationValue(transaction: IconTransactionType, addr: string): BigNumber {
   if (isSender(transaction, addr)) {
+    if (hasTransactionFailed(transaction)) {
+      return new BigNumber(transaction.transaction_fee);
+    }
     return transaction.value
       ? new BigNumber(transaction.value).plus(transaction.transaction_fee)
       : new BigNumber(0);
   } else {
+    if (hasTransactionFailed(transaction)) {
+      return new BigNumber(0);
+    }
     return transaction.value ? new BigNumber(transaction.value) : new BigNumber(0);
   }
 }
@@ -103,7 +118,7 @@ function txToOperation(
     senders: [transaction.from_address],
     recipients: [transaction.to_address],
     extra: {},
-    hasFailed: transaction.status !== "0x1",
+    hasFailed: hasTransactionFailed(transaction),
   };
 }
 

--- a/libs/coin-modules/coin-icon/src/buildTransaction.ts
+++ b/libs/coin-modules/coin-icon/src/buildTransaction.ts
@@ -22,7 +22,7 @@ const buildTransferTransaction = (
     .nonce(IconConverter.toHexNumber(getNonce(account)))
     .timestamp(IconConverter.toHexNumber(new Date().getTime() * 1000))
     .version(IconConverter.toHexNumber(RPC_VERSION));
-  if (stepLimit) {
+  if (stepLimit?.gt(0)) {
     icxTransferData.stepLimit(IconConverter.toHexNumber(stepLimit));
   }
 

--- a/libs/coin-modules/coin-icon/src/constants.ts
+++ b/libs/coin-modules/coin-icon/src/constants.ts
@@ -6,7 +6,11 @@ export const BERLIN_TESTNET_NID = 7;
 export const MAINNET_NID = 1;
 export const I_SCORE_UNIT = 1000;
 export const RPC_VERSION = 3;
-export const DEFAULT_STEP_LIMIT = 200000;
+// A plain ICX transfer's step cost under the default fee table, so this
+// fallback covers a real transfer even when the node's own estimate is
+// zero or unavailable. A value below the real transfer cost lets the
+// transaction land on-chain but run out of steps and revert.
+export const DEFAULT_STEP_LIMIT = 1_000_000;
 
 export const PREP_TYPE = {
   MAIN: "Main P-Rep",

--- a/libs/coin-modules/coin-icon/src/getFeesForTransaction.ts
+++ b/libs/coin-modules/coin-icon/src/getFeesForTransaction.ts
@@ -2,9 +2,33 @@ import { BigNumber } from "bignumber.js";
 import { getFees } from "./api/node";
 import { getStepPrice } from "./api/node";
 import { buildTransaction } from "./buildTransaction";
-import { ICON_DUMMY_ADDRESS } from "./constants";
+import { DEFAULT_STEP_LIMIT, ICON_DUMMY_ADDRESS } from "./constants";
 import { FEES_SAFETY_BUFFER, calculateAmount } from "./logic";
 import type { IconAccount, Transaction } from "./types";
+
+// A plain ICX transfer's step cost does not depend on the amount, so useAllAmount
+// estimates against a nominal amount instead of the full spendable balance, which
+// goloop's estimateStep cannot self-fund.
+const NOMINAL_AMOUNT = new BigNumber(1);
+
+const getEstimationAmount = ({
+  account,
+  transaction,
+}: {
+  account: IconAccount;
+  transaction: Transaction;
+}): BigNumber => {
+  if (transaction.useAllAmount) {
+    return NOMINAL_AMOUNT;
+  }
+  return calculateAmount({
+    account,
+    transaction: {
+      ...transaction,
+      fees: new BigNumber(0),
+    },
+  });
+};
 
 /**
  * Fetch the transaction fees for a transaction
@@ -23,24 +47,34 @@ const getEstimatedFees = async ({
     ...transaction,
     recipient: ICON_DUMMY_ADDRESS,
     // Always use a fake recipient to estimate fees
-    amount: calculateAmount({
-      account,
-      transaction: {
-        ...transaction,
-        fees: new BigNumber(0),
-      },
-    }), // Remove fees if present since we are fetching fees
+    amount: getEstimationAmount({ account, transaction }),
   };
+
+  let stepPrice: BigNumber;
   try {
-    const { unsigned } = await buildTransaction(account, tx);
-    const stepLimit = await getFees(unsigned, account);
-    transaction.stepLimit = stepLimit;
-    const stepPrice = await getStepPrice(account);
-    return stepLimit.multipliedBy(stepPrice);
+    stepPrice = await getStepPrice(account);
   } catch {
-    // Fix ME, the API of Icon throws an error when getting the fee with maximum balance
     return FEES_SAFETY_BUFFER;
   }
+
+  let stepLimit: BigNumber | undefined;
+  try {
+    const { unsigned } = await buildTransaction(account, tx);
+    stepLimit = await getFees(unsigned, account);
+  } catch {
+    stepLimit = undefined;
+  }
+
+  if (stepLimit && stepLimit.gt(0)) {
+    transaction.stepLimit = stepLimit;
+    return stepLimit.multipliedBy(stepPrice);
+  }
+
+  // A step limit of zero (or a failed estimate) means the node cannot simulate
+  // the transaction paying for its own steps; fall back to a default limit that
+  // stays in agreement with the fee returned below.
+  transaction.stepLimit = new BigNumber(DEFAULT_STEP_LIMIT);
+  return transaction.stepLimit.multipliedBy(stepPrice);
 };
 
 export default getEstimatedFees;


### PR DESCRIPTION
### 📝 Description

Stacked on #27, which carries the coin-tester package this fix is verified against. Base is `test/coin-tester-sodax-coverage`; the diff here is `coin-icon` only.

Two defects in `coin-icon` that a send on the local goloop devnet reproduces.

**Send-max produced a step limit of zero.** `getFeesForTransaction` estimated against the whole spendable balance. goloop's `icx_estimateStep` cannot simulate a transaction that spends everything and still pays for its own steps, so it answered `0x0`. That zero reached the transaction as its step limit and the node dropped the transaction. Send-max now estimates against a nominal amount of 1 loop — a plain ICX transfer's step cost does not depend on the amount — and a step limit of zero or an unavailable estimate falls back to `DEFAULT_STEP_LIMIT`.

**`DEFAULT_STEP_LIMIT` was itself too small.** It was 200,000. A plain ICX transfer costs 1,000,000 steps, measured on the devnet, so the fallback let a transaction land and then revert from running out of steps — the failure the fallback exists to prevent. It is now 1,000,000. `getFeesForTransaction` is its only consumer.

**A reverted transfer reported amount plus fee as its value.** A reverted transaction moves no value; the chain takes only the step cost. An OUT operation now reports the fee as its value, and an IN operation reports zero.

Unit tests cover all three. The end-to-end coverage runs from #27: the send-max leg of the main scenario, `revertedTransfer.test.ts` and `defaultStepLimitFallback.test.ts` all fail without this fix.

### 🔗 Context

- **Stacked on**: #27 (SODAX coin-tester)
- **JIRA / GitHub issue**:
- **ADR** (if any):
