### PR TITLE
test(coin-tester-sodax): review follow-up on the SODAX coin-tester

### DIFF
--- a/libs/coin-tester-modules/coin-tester-sodax/src/defaultStepLimitFallback.test.ts
+++ b/libs/coin-tester-modules/coin-tester-sodax/src/defaultStepLimitFallback.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_STEP_LIMIT } from "@ledgerhq/coin-icon/constants";
 import type { IconAccount, Transaction } from "@ledgerhq/coin-icon/types/index";
 import { convertICXtoLoop } from "@ledgerhq/coin-icon/logic";
 import type { AccountBridge, SignedOperation } from "@ledgerhq/types-live";
@@ -10,7 +11,7 @@ import { initIndexer, registerTransaction } from "./indexer";
 import { buildIconSigner } from "./signer";
 
 global.console = require("console");
-jest.setTimeout(120_000);
+jest.setTimeout(600_000);
 
 ["exit", "SIGINT", "SIGQUIT", "SIGTERM", "SIGUSR1", "SIGUSR2", "uncaughtException"].forEach(e =>
   process.on(e, async () => {
@@ -86,10 +87,10 @@ describe("SODAX DEFAULT_STEP_LIMIT fallback", () => {
     });
     transaction = await accountBridge.prepareTransaction(account, transaction);
 
-    // A real transfer's step cost is far above the old, undersized fallback;
-    // the fix's fallback stays large enough for the transaction to finalize
-    // instead of running out of steps and reverting.
-    expect(transaction.stepLimit).toBeDefined();
+    // The node's estimate is forced to zero, so the step limit on the
+    // transaction comes from the module's fallback. A limit below a plain
+    // transfer's real step cost lets the transaction land and then revert.
+    expect(transaction.stepLimit?.toFixed()).toBe(DEFAULT_STEP_LIMIT.toString());
 
     const signedOperation = await signTransaction(accountBridge, account, transaction);
     const optimistic = await accountBridge.broadcast({ account, signedOperation });

--- a/libs/coin-tester-modules/coin-tester-sodax/src/revertedTransfer.test.ts
+++ b/libs/coin-tester-modules/coin-tester-sodax/src/revertedTransfer.test.ts
@@ -47,12 +47,15 @@ async function signTransaction(
   });
 }
 
-// getEstimatedFees always estimates against a dummy EOA recipient
-// (ICON_DUMMY_ADDRESS), never the real one. A value transfer to a SCORE
-// invokes its fallback method, which costs more steps than a plain EOA
-// transfer, so the estimate under-provisions the step limit for any real
-// SCORE recipient. The transaction lands but runs out of steps and reverts,
-// consuming the full step limit as its fee.
+// KNOWN LIMITATION, not the behaviour we want: getEstimatedFees always
+// estimates against a dummy EOA recipient (ICON_DUMMY_ADDRESS), never the real
+// one. A value transfer to a SCORE invokes its fallback method, which costs
+// more steps than a plain EOA transfer, so the estimate under-provisions the
+// step limit for every SCORE recipient. The transaction lands, runs out of
+// steps and reverts, consuming the full step limit as its fee. Any send to a
+// SCORE address therefore fails, and the assertions below pin that failure.
+// Estimating against the real recipient is the fix; this test must be updated
+// to expect a finalized transfer once coin-icon does that.
 describe("SODAX reverted transfer", () => {
   let closeIndexer: (() => void) | undefined;
   let accountBridge: AccountBridge<Transaction, IconAccount>;


### PR DESCRIPTION
### 📝 Description

Stacked on #27. Merge #27 first; this branch targets `test/coin-tester-sodax-coverage`, not `develop`.

Review follow-up on three points in #27:

- `defaultStepLimitFallback.test.ts` asserted only that a step limit was set, so it passed against any fallback value, including the undersized one the test exists to catch. It now compares the limit against `DEFAULT_STEP_LIMIT`.
- The same suite ran with a 120s timeout while every other suite uses 600s. A cold goloop boot plus a sync does not fit in 120s, which made the suite a flake on CI.
- `revertedTransfer.test.ts` pinned a coin-icon defect without saying so: `getEstimatedFees` estimates against `ICON_DUMMY_ADDRESS`, an EOA, so every send to a SCORE address under-provisions its step limit and reverts. The comment now marks this as a known limitation and states what the test must expect once the estimate uses the real recipient.

No behaviour change in any coin module. Test-only.

### 🔗 Context

- **Stacked on**: #27 (SODAX coin-tester)
- **Also needs**: #28 (coin-icon send-max / reverted-transfer fix) — the fallback and reverted-transfer suites fail without it
- **JIRA / GitHub issue**:
- **ADR** (if any):