### PR TITLE
feat(ledger-wallet-framework): add family bridge hooks (LIVE-34359)

### DIFF
--- a/.changeset/receive-address-matcher-option.md
+++ b/.changeset/receive-address-matcher-option.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/ledger-wallet-framework": patch
+"@ledgerhq/live-common": patch
+---
+
+Accept an optional address matcher in `makeAccountBridgeReceive`.
+
+`makeAccountBridgeReceive` takes a `receiveAddressMatcher` option, typed as the new exported `ReceiveAddressMatcher`, which decides whether a device `getAddress` result belongs to the account and which address to surface. Without it, receive keeps comparing the result address against `account.freshAddress`. The generic coin framework's account bridge uses the option to apply the family's `BridgeApi.receiveAddressMatcher` hook, and falls back to the default comparison when the family declares no hook or its bridge api fails to load.

--- a/libs/ledger-wallet-framework/src/api/types.ts
+++ b/libs/ledger-wallet-framework/src/api/types.ts
@@ -1,10 +1,13 @@
-import type { AssetInfo, BalanceOptions } from "@ledgerhq/coin-module-framework/api/types";
+import type { AssetInfo, Balance, BalanceOptions } from "@ledgerhq/coin-module-framework/api/types";
 import type { CryptoCurrency, TokenCurrency } from "../types";
 import type {
+  Account,
   AccountReadiness,
   Operation as LiveOperation,
   StakingResources,
 } from "@ledgerhq/types-live";
+import type { ReceiveAddressMatcher } from "../derivation";
+import type { IterateResultBuilder } from "../bridge/jsHelpers";
 
 export type ChainSpecificRules = {
   getAccountShape: (address: string) => void;
@@ -61,4 +64,82 @@ export type BridgeApi = {
    * @returns The readiness of the account (ready flag + optional reason).
    */
   getAccountReadiness?: (currency: CryptoCurrency, address: string) => Promise<AccountReadiness>;
+  /**
+   * Optional hook called once per signed transaction, right after the framework builds the
+   * optimistic operation, letting a chain bridge attach fields the generic builder cannot
+   * produce on its own (e.g. a token identifier, a staking-node transition, or an
+   * address-checksum rule that differs by asset type within the same chain).
+   *
+   * @param account - The account the transaction was signed from.
+   * @param transaction - The transaction that was just signed.
+   * @param operation - The optimistic operation the generic framework built.
+   * @returns The enriched operation, or the same object unchanged when no enrichment is needed.
+   */
+  enrichOptimisticOperation?: (
+    account: Account,
+    transaction: Record<string, unknown>,
+    operation: LiveOperation,
+  ) => LiveOperation;
+  /**
+   * Optional hook called once per synced operation, letting a chain bridge map its own
+   * `operation.details` keys into `operation.extra` during sync. The generic adapter only
+   * copies a fixed, chain-agnostic allowlist; this hook is where a chain's own key names live,
+   * instead of growing that allowlist per family.
+   *
+   * @param details - The raw `details` bag attached to the synced core operation.
+   * @returns The keys to merge into the operation's `extra`.
+   */
+  mapOperationDetailsToExtra?: (details: Record<string, unknown>) => Record<string, unknown>;
+  /**
+   * When true, a native operation that pays only a fee (net value, fees excluded, is zero) is
+   * kept as its own type instead of being collapsed to `FEES`. The generic builder's default
+   * collapse targets chains where such an operation is always a token/contract fee leg — a
+   * distinct `FEES` operation would already exist there for that role. Some chains bill a
+   * standalone, non-fee-payer operation this way too (e.g. an account-auto-creation
+   * sub-transaction, billed as its own `OUT` with no net transfer), where collapsing it would
+   * misrepresent it.
+   */
+  keepFeesOnlyNativeOpType?: boolean;
+  /**
+   * Optional veto called once per token balance while building sub-accounts, letting a chain
+   * bridge suppress a sub-account the generic balance/operation data would otherwise produce
+   * (e.g. an untouched token whose on-chain balance reads as zero because balance is a live
+   * contract read, not evidence the account ever held or associated with it).
+   *
+   * @param balance - The token balance entry from `getBalance`.
+   * @param token - The resolved token currency for that balance.
+   * @param operations - The operations already resolved for that token, before sub-account assembly.
+   * @returns `false` to skip building a sub-account for this balance, `true` (or omitted) to build it.
+   */
+  shouldBuildTokenAccount?: (
+    balance: Balance,
+    token: TokenCurrency,
+    operations: LiveOperation[],
+  ) => boolean;
+  /**
+   * Optional hook to fetch chain-specific account resources that the generic Balance/Stake
+   * shape from `getBalance` has no field for. The returned object is spread directly into the
+   * synced account, so the chain owns both the key(s) it returns and their values.
+   *
+   * @param currencyId - The crypto currency id of the account being synced.
+   * @param address - The account address.
+   * @returns The chain-specific resources ready to spread into the account shape, or undefined
+   * when the account does not exist yet.
+   */
+  fetchAccountResources?: (currencyId: string, address: string) => Promise<object | undefined>;
+  /**
+   * Optional override for confirming that a device's `getAddress` result belongs to the given
+   * account. The default comparison checks the result's address against `account.freshAddress`;
+   * set this when the device never computes an address, so account identity must be confirmed
+   * some other way.
+   */
+  receiveAddressMatcher?: ReceiveAddressMatcher;
+  /**
+   * Optional override for how account scanning iterates derivation indexes. Set this when the
+   * chain's account ids are not derivable from the device path alone and must instead be
+   * resolved against the network (e.g. looking up which on-chain account ids were created for a
+   * device's public key). When omitted, account scanning derives each index's address straight
+   * from the device path.
+   */
+  buildIterateResult?: IterateResultBuilder;
 };

--- a/libs/ledger-wallet-framework/src/bridge/jsHelpers.test.ts
+++ b/libs/ledger-wallet-framework/src/bridge/jsHelpers.test.ts
@@ -12,11 +12,13 @@ import { firstValueFrom, Observable, of, Subscription, throwError } from "rxjs";
 import {
   AccountShapeInfo,
   bip32asBuffer,
+  makeAccountBridgeReceive,
   makeScanAccounts,
   makeSync,
   updateTransaction,
 } from "./jsHelpers";
 import { createEmptyHistoryCache } from "../account/balanceHistoryCache";
+import { WrongDeviceForAccount } from "@ledgerhq/errors";
 
 describe("updateTransaction", () => {
   it("should not update the transaction object", () => {
@@ -931,6 +933,95 @@ describe("bip32asBuffer", () => {
   ])("converts path for AppCoins with $name case", ({ derivationPath, expectedResult }) => {
     const path = bip32asBuffer(derivationPath);
     expect(path).toEqual(Buffer.from(expectedResult, "hex"));
+  });
+});
+
+describe("makeAccountBridgeReceive", () => {
+  const makeAccount = () =>
+    createAccount({
+      freshAddress: "address-1",
+      freshAddressPath: "44'/0'/0'/0/0",
+      seedIdentifier: "pubkey-1",
+    });
+  const deviceResult = { address: "address-1", path: "44'/0'/0'/0/0", publicKey: "pubkey-1" };
+
+  it("returns the device result when the address matches, without a matcher", async () => {
+    const getAddressFn = jest.fn().mockResolvedValue(deviceResult);
+    const receive = makeAccountBridgeReceive(getAddressFn);
+
+    await expect(
+      firstValueFrom(receive(makeAccount(), { deviceId: "device", verify: true })),
+    ).resolves.toEqual(deviceResult);
+  });
+
+  it("throws WrongDeviceForAccount on an address mismatch when verifying, without a matcher", async () => {
+    const getAddressFn = jest.fn().mockResolvedValue({ ...deviceResult, address: "address-2" });
+    const receive = makeAccountBridgeReceive(getAddressFn);
+
+    await expect(
+      firstValueFrom(receive(makeAccount(), { deviceId: "device", verify: true })),
+    ).rejects.toThrow(WrongDeviceForAccount);
+  });
+
+  it("keeps a mismatching address when not verifying, without a matcher", async () => {
+    const getAddressFn = jest.fn().mockResolvedValue({ ...deviceResult, address: "address-2" });
+    const receive = makeAccountBridgeReceive(getAddressFn);
+
+    await expect(
+      firstValueFrom(receive(makeAccount(), { deviceId: "device" })),
+    ).resolves.toMatchObject({
+      address: "address-2",
+    });
+  });
+
+  it("passes injectGetAddressParams through to the device call", async () => {
+    const getAddressFn = jest.fn().mockResolvedValue(deviceResult);
+    const receive = makeAccountBridgeReceive(getAddressFn, {
+      injectGetAddressParams: () => ({ forceFormat: "bech32" }),
+    });
+
+    await firstValueFrom(receive(makeAccount(), { deviceId: "device", verify: true }));
+
+    expect(getAddressFn).toHaveBeenCalledWith(
+      "device",
+      expect.objectContaining({ forceFormat: "bech32" }),
+    );
+  });
+
+  it("lets a matcher accept on another criterion and surface its own address", async () => {
+    const getAddressFn = jest.fn().mockResolvedValue({ ...deviceResult, address: "" });
+    const receive = makeAccountBridgeReceive(getAddressFn, {
+      receiveAddressMatcher: (result, a) => ({
+        matches: result.publicKey === a.seedIdentifier,
+        address: a.freshAddress,
+      }),
+    });
+
+    await expect(
+      firstValueFrom(receive(makeAccount(), { deviceId: "device", verify: true })),
+    ).resolves.toMatchObject({ address: "address-1" });
+  });
+
+  it("throws WrongDeviceForAccount when the matcher rejects a matching address", async () => {
+    const getAddressFn = jest.fn().mockResolvedValue(deviceResult);
+    const receive = makeAccountBridgeReceive(getAddressFn, {
+      receiveAddressMatcher: () => ({ matches: false, address: "address-1" }),
+    });
+
+    await expect(
+      firstValueFrom(receive(makeAccount(), { deviceId: "device", verify: true })),
+    ).rejects.toThrow(WrongDeviceForAccount);
+  });
+
+  it("awaits an asynchronous matcher", async () => {
+    const getAddressFn = jest.fn().mockResolvedValue(deviceResult);
+    const receive = makeAccountBridgeReceive(getAddressFn, {
+      receiveAddressMatcher: async () => ({ matches: true, address: "address-3" }),
+    });
+
+    await expect(
+      firstValueFrom(receive(makeAccount(), { deviceId: "device", verify: true })),
+    ).resolves.toMatchObject({ address: "address-3" });
   });
 });
 

--- a/libs/ledger-wallet-framework/src/bridge/jsHelpers.ts
+++ b/libs/ledger-wallet-framework/src/bridge/jsHelpers.ts
@@ -40,7 +40,7 @@ import {
 import { shouldRetainPendingOperation } from "../account/pending";
 import { shouldShowNewAccount } from "../account/support";
 import getAddressWrapper, { GetAddressFn } from "./getAddressWrapper";
-import type { GetAddressResult } from "../derivation";
+import type { GetAddressResult, ReceiveAddressMatcher } from "../derivation";
 import type { CryptoCurrency } from "../types";
 import type {
   Account,
@@ -631,12 +631,19 @@ export const makeScanAccounts =
       return unsubscribe;
     });
 
+const defaultReceiveAddressMatcher: ReceiveAddressMatcher = (result, account) => ({
+  matches: result.address === account.freshAddress,
+  address: result.address,
+});
+
 export function makeAccountBridgeReceive<A extends Account = Account>(
   getAddressFn: GetAddressFn,
   {
     injectGetAddressParams,
+    receiveAddressMatcher = defaultReceiveAddressMatcher as ReceiveAddressMatcher<A>,
   }: {
     injectGetAddressParams?: (account: A) => any;
+    receiveAddressMatcher?: ReceiveAddressMatcher<A>;
   } = {},
 ) {
   return (
@@ -660,15 +667,16 @@ export function makeAccountBridgeReceive<A extends Account = Account>(
       ...(injectGetAddressParams && injectGetAddressParams(account)),
     };
     return from(
-      getAddressFn(deviceId, arg).then(r => {
-        const accountAddress = account.freshAddress;
+      (async () => {
+        const result = await getAddressFn(deviceId, arg);
+        const { matches, address } = await receiveAddressMatcher(result, account);
 
-        if (verify && r.address !== accountAddress) {
+        if (verify && !matches) {
           throw new WrongDeviceForAccount();
         }
 
-        return r;
-      }),
+        return { ...result, address };
+      })(),
     );
   };
 }

--- a/libs/ledger-wallet-framework/src/derivation.ts
+++ b/libs/ledger-wallet-framework/src/derivation.ts
@@ -1,7 +1,7 @@
 import { getCurrenciesResolver } from "./currencies/resolver";
 import { getEnv } from "@ledgerhq/live-env";
 import type { CryptoCurrency } from "./types";
-import { DerivationMode } from "@ledgerhq/types-live";
+import { Account, DerivationMode } from "@ledgerhq/types-live";
 
 type ModeSpec = {
   mandatoryEmptyAccountSkip?: number;
@@ -29,6 +29,19 @@ export type GetAddressResult = {
   publicKey: string;
   chainCode?: string;
 };
+/**
+ * Decides whether a device's `getAddress` result belongs to the given account,
+ * and what address to surface to the caller.
+ *
+ * @param result - The raw result returned by the device's address derivation.
+ * @param account - The account receive was called for.
+ * @returns Whether the result matches the account, and the address to surface to the caller.
+ */
+export type ReceiveAddressMatcher<A extends Account = Account> = (
+  result: GetAddressResult,
+  account: A,
+) => { matches: boolean; address: string } | Promise<{ matches: boolean; address: string }>;
+
 export type GetAddressOptions = {
   currency: CryptoCurrency;
   path: string;


### PR DESCRIPTION
### 🪜 Stack

Stacked PRs. Merge in order, 1 first — each one targets the branch above it.

1. #33 `feat(ledger-wallet-framework): add family bridge hooks`  ← this PR
2. #34 `feat(generic-coin-framework): add token-associate mode and family hooks`
3. #35 `feat(hedera): migrate to the generic coin framework`
4. #36 `refactor(hedera): rewire the desktop UI onto GenericTransaction`
5. #37 `refactor(hedera): rewire the mobile UI onto GenericTransaction`
6. #38 `test(coin-tester-hedera): add end-to-end coin-tester for hedera`

---

### 📝 Description

First PR of the Hedera coin-module migration stack. It adds the framework-level
extension points that the migration needs, and nothing else. Every change is
additive and optional, so no existing family changes behaviour.

`src/derivation.ts`
- New `ReceiveAddressMatcher` type. It decides if a device `getAddress` result
  belongs to an account, and which address to show to the caller.

`src/bridge/jsHelpers.ts`
- `makeAccountBridgeReceive` accepts a `receiveAddressMatcher` option. The
  default matcher keeps the current behaviour: compare the device address with
  `account.freshAddress`. Hedera needs the override because the device never
  computes the account id.

`src/api/types.ts` — new optional `BridgeApi` hooks:
- `enrichOptimisticOperation` — lets a family attach fields the generic builder
  cannot produce (token id, staking-node transition, per-asset checksum rule).
- `mapOperationDetailsToExtra` — maps a family's own `operation.details` keys
  into `operation.extra` during sync, instead of growing a shared allowlist.
- `shouldBuildTokenAccount` — vetoes a sub-account the generic balance data
  would otherwise create.
- `fetchAccountResources` — fetches family-specific account fields that the
  generic `Balance`/`Stake` shape has no room for.
- `keepFeesOnlyNativeOpType` — keeps a fee-only native operation as its own
  type instead of collapsing it to `FEES`.
- `buildIterateResult` — overrides how account scanning iterates derivation
  indexes, for chains whose account ids are not derivable from the device path.

New unit tests cover the receive matcher paths in `jsHelpers`.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-34359
- **ADR** (if any): —
