### PR TITLE
feat(generic-coin-framework): add token-associate mode and family hooks (LIVE-34359)

### DIFF
--- a/.changeset/generic-framework-family-op-shaping-hooks.md
+++ b/.changeset/generic-framework-family-op-shaping-hooks.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-common": patch
+"@ledgerhq/ledger-wallet-framework": patch
+---
+
+Let a family opt out of two generic operation-shaping heuristics.
+
+`BridgeApi` gains `keepFeesOnlyNativeOpType` and `shouldBuildTokenAccount`. The first keeps a native operation with zero net value as its own type instead of collapsing it to `FEES`; Hedera bills account auto-creation that way, and the collapse mislabeled it. The second vetoes a token sub-account the balance data would otherwise produce; an ERC20 balance is a live contract read that returns zero for a token the account never held, so the generic builder created sub-accounts the legacy bridge did not.

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/accountBridge.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/accountBridge.test.ts
@@ -1,0 +1,137 @@
+import type { Account } from "@ledgerhq/types-live";
+import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
+import { lastValueFrom, toArray } from "rxjs";
+import { getCoinFrameworkAccountBridge } from "./accountBridge";
+import { getBridgeApi } from "./bridge";
+import type { CoinFrameworkSigner } from "./types";
+
+// A matcher that ignores the device address entirely and confirms identity from the public key,
+// standing in for any family whose device never computes the account address.
+const publicKeyMatcher: NonNullable<BridgeApi["receiveAddressMatcher"]> = (result, account) => ({
+  matches: result.publicKey === account.seedIdentifier,
+  address: account.freshAddress,
+});
+
+jest.mock("./bridge", () => ({ getBridgeApi: jest.fn() }));
+
+const mockedGetBridgeApi = getBridgeApi as jest.MockedFunction<typeof getBridgeApi>;
+
+const baseAccount = {
+  freshAddress: "0.0.1234",
+  freshAddressPath: "44'/3030'/0'/0'/0'",
+  seedIdentifier: "302a300506032b6570032100aabbccddeeff",
+  derivationMode: "",
+  currency: { id: "some-currency" },
+} as unknown as Account;
+
+function makeSigner(getAddressResult: {
+  address: string;
+  path: string;
+  publicKey: string;
+}): CoinFrameworkSigner {
+  return {
+    getAddress: jest.fn().mockResolvedValue(getAddressResult),
+    context: jest.fn() as unknown as CoinFrameworkSigner["context"],
+  };
+}
+
+// The network name passed here is deliberately unrelated to any real family: it must have no
+// bearing on which matcher runs, only `bridgeApi.receiveAddressMatcher` does.
+const arbitraryNetwork = "not-a-real-family";
+
+describe("getCoinFrameworkAccountBridge receive", () => {
+  beforeEach(() => {
+    mockedGetBridgeApi.mockReset();
+  });
+
+  it("compares by freshAddress when the bridge api sets no receiveAddressMatcher hook", async () => {
+    mockedGetBridgeApi.mockResolvedValue({} as BridgeApi);
+    const account = {
+      ...baseAccount,
+      freshAddress: "0xabc",
+      currency: { id: "ethereum" },
+    } as unknown as Account;
+    const signer = makeSigner({
+      address: "0xabc",
+      path: account.freshAddressPath,
+      publicKey: "pub",
+    });
+    const bridge = await getCoinFrameworkAccountBridge(arbitraryNetwork, "local", signer);
+
+    const events = await lastValueFrom(
+      bridge.receive(account, { deviceId: "", verify: true }).pipe(toArray()),
+    );
+
+    expect(events.at(-1)).toMatchObject({ address: "0xabc" });
+  });
+
+  it("rejects the default comparison when the device address does not match freshAddress, even without a hook", async () => {
+    mockedGetBridgeApi.mockResolvedValue({} as BridgeApi);
+    const account = {
+      ...baseAccount,
+      freshAddress: "0xabc",
+      currency: { id: "ethereum" },
+    } as unknown as Account;
+    const signer = makeSigner({
+      address: "0xdef",
+      path: account.freshAddressPath,
+      publicKey: "pub",
+    });
+    const bridge = await getCoinFrameworkAccountBridge(arbitraryNetwork, "local", signer);
+
+    await expect(
+      lastValueFrom(bridge.receive(account, { deviceId: "", verify: true }).pipe(toArray())),
+    ).rejects.toThrow("WrongDeviceForAccount");
+  });
+
+  it("uses the bridge api's receiveAddressMatcher hook to accept a public-key match, regardless of the network name", async () => {
+    mockedGetBridgeApi.mockResolvedValue({ receiveAddressMatcher: publicKeyMatcher } as BridgeApi);
+    const signer = makeSigner({
+      address: "302a300506032b6570032100aabbccddeeff",
+      path: baseAccount.freshAddressPath,
+      publicKey: "302a300506032b6570032100aabbccddeeff",
+    });
+    const bridge = await getCoinFrameworkAccountBridge(arbitraryNetwork, "local", signer);
+
+    const events = await lastValueFrom(
+      bridge.receive(baseAccount, { deviceId: "", verify: true }).pipe(toArray()),
+    );
+
+    expect(events.at(-1)).toMatchObject({ address: "0.0.1234" });
+  });
+
+  it("rejects a public-key mismatch through the hook even when the device address equals freshAddress", async () => {
+    mockedGetBridgeApi.mockResolvedValue({ receiveAddressMatcher: publicKeyMatcher } as BridgeApi);
+    const signer = makeSigner({
+      address: baseAccount.freshAddress,
+      path: baseAccount.freshAddressPath,
+      publicKey: "302a300506032b6570032100deadbeef",
+    });
+    const bridge = await getCoinFrameworkAccountBridge(arbitraryNetwork, "local", signer);
+
+    await expect(
+      lastValueFrom(bridge.receive(baseAccount, { deviceId: "", verify: true }).pipe(toArray())),
+    ).rejects.toThrow("WrongDeviceForAccount");
+  });
+
+  it("falls back to the default comparison when the family's bridge api fails to load", async () => {
+    mockedGetBridgeApi.mockRejectedValue(new Error("module load failed"));
+    const account = {
+      ...baseAccount,
+      freshAddress: "0xabc",
+      currency: { id: "ethereum" },
+    } as unknown as Account;
+    const signer = makeSigner({
+      address: "0xabc",
+      path: account.freshAddressPath,
+      publicKey: "pub",
+    });
+    const bridge = await getCoinFrameworkAccountBridge(arbitraryNetwork, "local", signer);
+
+    const events = await lastValueFrom(
+      bridge.receive(account, { deviceId: "", verify: true }).pipe(toArray()),
+    );
+
+    expect(events.at(-1)).toMatchObject({ address: "0xabc" });
+  });
+});

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/accountBridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/accountBridge.ts
@@ -1,3 +1,4 @@
+import { log } from "@ledgerhq/logs";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { makeSync } from "../jsHelpers";
 import { genericGetAccountShape } from "./getAccountShape";
@@ -7,7 +8,9 @@ import {
   updateTransaction,
 } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import getAddressWrapper from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
+import type { ReceiveAddressMatcher } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { getSigner } from "./signer";
+import { getBridgeApi } from "./bridge";
 import { genericPrepareTransaction } from "./prepareTransaction";
 import { genericGetTransactionStatus } from "./getTransactionStatus";
 import { genericEstimateMaxSpendable } from "./estimateMaxSpendable";
@@ -20,6 +23,30 @@ import { genericValidateAddress } from "./validateAddress";
 import { getAccountRawAssignHooks } from "./accountRawAssign";
 import type { GenericTransaction, CoinFrameworkSigner } from "./types";
 
+const defaultAddressMatcher: ReceiveAddressMatcher = (result, account) => ({
+  matches: result.address === account.freshAddress,
+  address: result.address,
+});
+
+/**
+ * Resolves the family's `receiveAddressMatcher` hook per account, since a family's bridge api
+ * can be a function of the currency. A family that declares no hook, and a family whose
+ * `bridge/api` module fails to load, both fall back to the default comparison so that receive
+ * keeps working.
+ */
+const bridgeApiAddressMatcher =
+  (network: string): ReceiveAddressMatcher =>
+  async (result, account) => {
+    let matcher = defaultAddressMatcher;
+    try {
+      const bridgeApi = await getBridgeApi(account.currency, network);
+      matcher = bridgeApi.receiveAddressMatcher ?? defaultAddressMatcher;
+    } catch (e) {
+      log("warn", `receive: falling back to the default address matcher for ${network}`, e);
+    }
+    return matcher(result, account);
+  };
+
 export async function getCoinFrameworkAccountBridge(
   network: string,
   kind: string,
@@ -29,7 +56,9 @@ export async function getCoinFrameworkAccountBridge(
   const { assignFromAccountRaw, assignToAccountRaw } = await getAccountRawAssignHooks(network);
   return {
     sync: makeSync({ getAccountShape: genericGetAccountShape(network, kind), postSync }),
-    receive: makeAccountBridgeReceive(getAddressWrapper(signer.getAddress)),
+    receive: makeAccountBridgeReceive(getAddressWrapper(signer.getAddress), {
+      receiveAddressMatcher: bridgeApiAddressMatcher(network),
+    }),
     createTransaction: createTransaction,
     updateTransaction: updateTransaction<GenericTransaction>,
     prepareTransaction: genericPrepareTransaction(network, kind),

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/buildSubAccounts.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/buildSubAccounts.test.ts
@@ -236,6 +236,25 @@ describe("buildSubAccounts", () => {
       },
     ]);
   });
+
+  it("skips a balance vetoed by shouldBuildTokenAccount", async () => {
+    const subAccounts = await buildSubAccounts({
+      accountId: "accountId",
+      allTokenAssetsBalances: [
+        { value: 0n, asset: { type: "token", assetReference: "untouched", assetOwner: "owner" } },
+        { value: 30n, asset: { type: "token", assetReference: "usdt", assetOwner: "owner" } },
+      ],
+      syncConfig: { blacklistedTokenIds: [] } as unknown as SyncConfig,
+      operations: [],
+      getTokenFromAsset: async asset =>
+        asset.type === "token" ? ({ id: asset.assetReference } as TokenCurrency) : undefined,
+      shouldBuildTokenAccount: (balance, _token, operations) =>
+        !(balance.value === 0n && operations.length === 0),
+    });
+
+    expect(subAccounts).toHaveLength(1);
+    expect(subAccounts[0].token.id).toBe("usdt");
+  });
 });
 
 describe("mergeSubAccounts", () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/buildSubAccounts.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/buildSubAccounts.ts
@@ -65,12 +65,18 @@ export async function buildSubAccounts({
   syncConfig,
   operations,
   getTokenFromAsset,
+  shouldBuildTokenAccount,
 }: {
   accountId: string;
   allTokenAssetsBalances: Balance[];
   syncConfig: SyncConfig;
   operations: OperationCommon[];
   getTokenFromAsset?: (asset: AssetInfo) => Promise<TokenCurrency | undefined>;
+  shouldBuildTokenAccount?: (
+    balance: Balance,
+    token: TokenCurrency,
+    operations: OperationCommon[],
+  ) => boolean;
 }): Promise<TokenAccount[]> {
   const { blacklistedTokenIds = [] } = syncConfig;
   const tokenAccounts: TokenAccount[] = [];
@@ -89,16 +95,22 @@ export async function buildSubAccounts({
   for (const { balance, token } of tokenBalances) {
     // NOTE: for future tokens, will need to check over currencyName/standard(erc20,trc10,trc20, etc)/id
     if (token && !blacklistedTokenIds.includes(token.id)) {
+      const tokenOperations = operations.filter(
+        op =>
+          op.extra.assetReference === balance.asset?.["assetReference"] &&
+          op.extra.assetOwner === balance.asset?.["assetOwner"], // NOTE: we could narrow type
+      );
+
+      if (shouldBuildTokenAccount && !shouldBuildTokenAccount(balance, token, tokenOperations)) {
+        continue;
+      }
+
       tokenAccounts.push(
         buildTokenAccount({
           parentAccountId: accountId,
           assetBalance: balance,
           token,
-          operations: operations.filter(
-            op =>
-              op.extra.assetReference === balance.asset?.["assetReference"] &&
-              op.extra.assetOwner === balance.asset?.["assetOwner"], // NOTE: we could narrow type
-          ),
+          operations: tokenOperations,
         }),
       );
     }

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/currencyBridge.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/currencyBridge.test.ts
@@ -1,0 +1,103 @@
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { apiClient } from "@ledgerhq/coin-hedera/network/api";
+import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
+import BigNumber from "bignumber.js";
+import { lastValueFrom, toArray } from "rxjs";
+import { getCoinFrameworkCurrencyBridge } from "./currencyBridge";
+
+jest.mock("@ledgerhq/coin-hedera/network/api", () => ({
+  apiClient: { getAccountsForPublicKey: jest.fn() },
+}));
+
+jest.mock("./getAccountShape", () => ({
+  // `used: true` only for hedera, so the fallback-to-default test (run against a family with no
+  // buildIterateResult hook) breaks out of scanning after its first empty index instead of
+  // walking every derivable index.
+  genericGetAccountShape: () => async (info: { address: string; currency: { id: string } }) => ({
+    id: `js:2:${info.currency.id}:${info.address}:`,
+    used: info.currency.id === "hedera",
+    balance: new BigNumber(0),
+    spendableBalance: new BigNumber(0),
+    operations: [],
+    operationsCount: 0,
+  }),
+}));
+
+const currency = getCryptoCurrencyById("hedera");
+const bitcoinCurrency = getCryptoCurrencyById("bitcoin");
+
+const customSigner = {
+  getAddress: jest.fn().mockResolvedValue({
+    address: "302a300506032b6570032100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    publicKey:
+      "302a300506032b6570032100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    path: "44/3030",
+  }),
+  context: jest.fn(),
+} as never;
+
+describe("getCoinFrameworkCurrencyBridge", () => {
+  beforeAll(() => {
+    // hederaBuildIterateResult reads its config off LiveConfig; outside the app's runtime
+    // bootstrap (which loads it from the remote config provider), it stays unset.
+    jest.spyOn(LiveConfig, "getValueByKey").mockReturnValue({
+      networkType: "mainnet",
+      useNetworkTimestamp: true,
+      apiUrls: { mirrorNode: "", hgraph: "" },
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("resolves hedera account ids from the mirror node instead of the device public key", async () => {
+    jest
+      .mocked(apiClient.getAccountsForPublicKey)
+      .mockResolvedValue([{ account: "0.0.100" }, { account: "0.0.200" }] as never);
+
+    const currencyBridge = await getCoinFrameworkCurrencyBridge("hedera", "local", customSigner);
+
+    const events = await lastValueFrom(
+      currencyBridge
+        .scanAccounts({
+          currency,
+          deviceId: "",
+          syncConfig: { paginationConfig: {}, blacklistedTokenIds: [] },
+        })
+        .pipe(toArray()),
+    );
+
+    const discovered = events.filter(e => e.type === "discovered");
+    expect(
+      discovered.map(e => (e as { account: { freshAddress: string } }).account.freshAddress),
+    ).toEqual(["0.0.100", "0.0.200"]);
+    // The scan must stop once the mirror node's account list is exhausted,
+    // not run through every one of the 255 derivable indexes.
+    expect(jest.mocked(apiClient.getAccountsForPublicKey)).toHaveBeenCalledTimes(3);
+  });
+
+  it("falls back to the default iterate result builder for a family with no buildIterateResult hook", async () => {
+    const currencyBridge = await getCoinFrameworkCurrencyBridge("bitcoin", "local", customSigner);
+
+    const events = await lastValueFrom(
+      currencyBridge
+        .scanAccounts({
+          currency: bitcoinCurrency,
+          deviceId: "",
+          syncConfig: { paginationConfig: {}, blacklistedTokenIds: [] },
+        })
+        .pipe(toArray()),
+    );
+
+    const discovered = events.filter(e => e.type === "discovered");
+    expect(discovered.length).toBeGreaterThan(0);
+    discovered.forEach(e => {
+      expect((e as { account: { freshAddress: string } }).account.freshAddress).toBe(
+        "302a300506032b6570032100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      );
+    });
+    // The mirror-node lookup is hedera-specific; a family without the hook must never reach it.
+    expect(apiClient.getAccountsForPublicKey).not.toHaveBeenCalled();
+  });
+});

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/currencyBridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/currencyBridge.ts
@@ -1,5 +1,9 @@
+import { defer, switchMap } from "rxjs";
+import { log } from "@ledgerhq/logs";
 import { makeScanAccounts } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
+import type { IterateResultBuilder } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import type { CurrencyBridge } from "@ledgerhq/types-live";
+import { getBridgeApi } from "./bridge";
 import { genericGetAccountShape } from "./getAccountShape";
 import { getSigner } from "./signer";
 import type { CoinFrameworkSigner } from "./types";
@@ -11,11 +15,35 @@ export async function getCoinFrameworkCurrencyBridge(
   customSigner?: CoinFrameworkSigner,
 ): Promise<CurrencyBridge> {
   const signer = customSigner ?? (await getSigner(network));
-  return {
-    scanAccounts: makeScanAccounts({
-      getAccountShape: genericGetAccountShape(network, kind),
-      getAddressFn: signer.getAddress.bind(signer),
-      postSync,
-    }),
-  };
+  const getAddressFn = signer.getAddress.bind(signer);
+
+  // A family's bridge api can be a function of the currency, and the currency is only known
+  // once `scanAccounts` is invoked, so `buildIterateResult` is resolved per call instead of once
+  // here. Leaving it `undefined` (no hook declared, or the `bridge/api` module fails to load)
+  // makes `makeScanAccounts` fall back to its own device-path-derived default.
+  const scanAccounts: CurrencyBridge["scanAccounts"] = opts =>
+    defer(async (): Promise<IterateResultBuilder | undefined> => {
+      try {
+        const bridgeApi = await getBridgeApi(opts.currency, network);
+        return bridgeApi.buildIterateResult;
+      } catch (e) {
+        log(
+          "warn",
+          `scanAccounts: falling back to the default iterate result builder for ${network}`,
+          e,
+        );
+        return undefined;
+      }
+    }).pipe(
+      switchMap(buildIterateResult =>
+        makeScanAccounts({
+          getAccountShape: genericGetAccountShape(network, kind),
+          getAddressFn,
+          postSync,
+          buildIterateResult,
+        })(opts),
+      ),
+    );
+
+  return { scanAccounts };
 }

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -133,11 +133,12 @@ function parentOpsFromNativeOps(
   accountId: string,
   subOperations: OperationCommon[],
   internalOperations: OperationCommon[],
+  keepFeesOnlyNativeOpType: boolean,
 ): OperationCommon[] {
   const out: OperationCommon[] = [];
   for (const nativeOp of nativeOps) {
     // Native outgoing operation with value 0 (only fees) => output as single FEES op
-    if (isFeesOnlyNativeOp(nativeOp)) {
+    if (!keepFeesOnlyNativeOpType && isFeesOnlyNativeOp(nativeOp)) {
       out.push(
         cleanedOperation({
           id: encodeOperationId(accountId, nativeOp.hash, "FEES"),
@@ -219,6 +220,7 @@ function parentOpsForTxWithNonInternalOperations(
   newSubAccounts: TokenAccount[],
   accountId: string,
   address: string,
+  keepFeesOnlyNativeOpType: boolean,
 ): OperationCommon[] {
   const nativeOps = transactionOps.filter(isNativeLiveOp);
   // inferSubOperations returns types-live Operation[]; we use OperationCommon in this bridge
@@ -227,7 +229,13 @@ function parentOpsForTxWithNonInternalOperations(
 
   // If transaction has native ops, use them as parents
   if (nativeOps.length > 0)
-    return parentOpsFromNativeOps(nativeOps, accountId, subOperations, internalOperations);
+    return parentOpsFromNativeOps(
+      nativeOps,
+      accountId,
+      subOperations,
+      internalOperations,
+      keepFeesOnlyNativeOpType,
+    );
 
   // If transaction has no native ops, create a synthetic parent
   const firstOp = transactionOps[0];
@@ -288,6 +296,7 @@ function buildParentOperations(
   newInternalOperations: OperationCommon[],
   accountId: string,
   address: string,
+  keepFeesOnlyNativeOpType: boolean,
 ): OperationCommon[] {
   const nonInternalByHash = groupBy(newNonInternalOperations, "hash");
   const internalByHash = groupBy(newInternalOperations, "hash");
@@ -305,6 +314,7 @@ function buildParentOperations(
         newSubAccounts,
         accountId,
         address,
+        keepFeesOnlyNativeOpType,
       ),
     );
   }
@@ -368,11 +378,12 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
         })
       : Promise.resolve(undefined);
 
-    const [blockInfo, balanceRes, validators, readiness] = await Promise.all([
+    const [blockInfo, balanceRes, validators, readiness, accountResources] = await Promise.all([
       coinModuleApi.lastBlock(),
       coinModuleApi.getBalance(address, bridgeApi.balanceOptions),
       validatorsPromise,
       readinessPromise,
+      bridgeApi.fetchAccountResources?.(currency.id, address) ?? Promise.resolve(undefined),
     ]);
 
     const nativeAsset = extractBalance(balanceRes, "native");
@@ -479,7 +490,21 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
     });
     const newOps = newCoreOps
       .filter(op => !isNftCoreOp(op) && (!isIncomingCoreOp(op) || !op.tx.failed))
-      .map(op => adaptCoreOperationToLiveOperation(accountId, op)) as OperationCommon[];
+      .map(op => {
+        const operation = adaptCoreOperationToLiveOperation(accountId, op) as OperationCommon;
+        if (!bridgeApi.mapOperationDetailsToExtra) return operation;
+        let mappedExtra: Record<string, unknown> = {};
+        try {
+          mappedExtra = bridgeApi.mapOperationDetailsToExtra(op.details ?? {});
+        } catch (e) {
+          log(
+            "generic-coin-framework",
+            "mapOperationDetailsToExtra failed, falling back to base extra",
+            { error: e instanceof Error ? e.message : String(e) },
+          );
+        }
+        return { ...operation, extra: { ...operation.extra, ...mappedExtra } };
+      }) as OperationCommon[];
 
     const newAssetOperations = newOps.filter(
       operation =>
@@ -501,6 +526,7 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
       syncConfig,
       operations: newAssetOperations,
       getTokenFromAsset: bridgeApi.getTokenFromAsset,
+      shouldBuildTokenAccount: bridgeApi.shouldBuildTokenAccount,
     });
     const subAccounts = syncFromScratch
       ? newSubAccounts
@@ -512,6 +538,7 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
       newInternalOperations,
       accountId,
       address,
+      bridgeApi.keepFeesOnlyNativeOpType ?? false,
     );
     // Try to refresh known pending and broadcasted operations (if not already updated)
     // Useful for integrations without explorers
@@ -553,7 +580,7 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
       stakingShape = { stakingResources: enrichedStakingResources };
     }
 
-    const res: Partial<Account> & {
+    const frameworkFields: Partial<Account> & {
       stakingResources?: StakingResources;
       stakingPositions?: StakingPositionOnAccount[];
     } = {
@@ -572,6 +599,28 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
       // readiness lookup retains the last persisted value instead of clearing it.
       ...(readiness !== undefined ? { readiness } : {}),
       ...stakingShape,
+    };
+
+    // A family's fetchAccountResources hook is opaque to the framework; guard against it
+    // returning a key that shadows a framework-owned field. This must never happen — surfaced
+    // loudly rather than thrown, since a sync failure here would break an otherwise-healthy
+    // account.
+    if (accountResources) {
+      const collidingKeys = Object.keys(accountResources).filter(key => key in frameworkFields);
+      if (collidingKeys.length > 0) {
+        console.error(
+          `genericGetAccountShape: fetchAccountResources returned key(s) owned by the framework, dropped: ${collidingKeys.join(", ")}`,
+        );
+      }
+    }
+
+    const res: Partial<Account> & {
+      stakingResources?: StakingResources;
+      stakingPositions?: StakingPositionOnAccount[];
+      [key: string]: unknown;
+    } = {
+      ...(accountResources ?? {}),
+      ...frameworkFields,
     };
     return res;
   };

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/postSync.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/postSync.test.ts
@@ -94,4 +94,43 @@ describe("postSync", () => {
       ],
     });
   });
+
+  it("keeps a hedera-shaped pending op: sequence 0 against synced ops with no sequence", () => {
+    const pending = {
+      hash: "0.0.4@1753600000.000000001",
+      type: "OUT",
+      transactionSequenceNumber: new BigNumber(0),
+    } as unknown as Account["pendingOperations"][number];
+    const initialAccount = {
+      operations: [],
+      pendingOperations: [pending],
+    } as unknown as Account;
+    const synced = {
+      operations: [
+        { hash: "0.0.4@1753500000.000000001", type: "OUT", transactionSequenceNumber: undefined },
+      ],
+      pendingOperations: [],
+    } as unknown as Account;
+
+    expect(postSync(initialAccount, synced).pendingOperations).toHaveLength(1);
+  });
+
+  it("drops a hedera-shaped pending op once its hash appears in the synced list", () => {
+    const hash = "0.0.4@1753600000.000000001";
+    const pending = {
+      hash,
+      type: "OUT",
+      transactionSequenceNumber: new BigNumber(0),
+    } as unknown as Account["pendingOperations"][number];
+    const initialAccount = {
+      operations: [],
+      pendingOperations: [pending],
+    } as unknown as Account;
+    const synced = {
+      operations: [{ hash, type: "OUT", transactionSequenceNumber: undefined }],
+      pendingOperations: [],
+    } as unknown as Account;
+
+    expect(postSync(initialAccount, synced).pendingOperations).toHaveLength(0);
+  });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
@@ -103,7 +103,17 @@ export const genericSignOperation =
           signedInfo.txnSig,
           signedInfo.publicKey,
         );
-        const operation = buildOptimisticOperation(account, transaction, signedInfo.sequence);
+        const builtOperation = buildOptimisticOperation(account, transaction, signedInfo.sequence);
+        let operation = builtOperation;
+        if (bridgeApi.enrichOptimisticOperation) {
+          try {
+            operation = bridgeApi.enrichOptimisticOperation(account, transaction, builtOperation);
+          } catch (e) {
+            log("Generic coin-framework", "enrichOptimisticOperation failed, falling back to base operation", {
+              error: e instanceof Error ? e.message : String(e),
+            });
+          }
+        }
         if (!operation.id) {
           log("Generic coin-framework", "buildOptimisticOperation", operation);
         }

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
@@ -489,6 +489,118 @@ describe("genericGetAccountShape", () => {
       expect(operation?.type).toBe("FEES");
     });
 
+    test("mapOperationDetailsToExtra merges into operation.extra, hook keys winning on collision", async () => {
+      const address = `${currency.id}_addr-hook`;
+      const opFromList = {
+        hash: "tx-hash-hook",
+        type: "OUT",
+        tx: { failed: false },
+        details: { note: "onchain-detail" },
+      };
+
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 0n, locked: 0n }]);
+      extractBalanceMock.mockReturnValue({ value: 0n, locked: 0n });
+      listOperationsMock.mockResolvedValue({ items: [opFromList], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 1 });
+      adaptCoreOperationToLiveOperationMock.mockImplementation((_accId, op: any) => ({
+        hash: op.hash,
+        type: op.type,
+        blockHeight: 1,
+        extra: {
+          // Non-empty assetReference/feePayer route this through the token-only synthetic-parent
+          // path, which passes `extra` through untouched: isolates the hook's merge from the
+          // native-op value/fee logic.
+          assetReference: "usdc",
+          assetOwner: "owner",
+          feePayer: address,
+          keptKey: "from-adapter",
+        },
+      }));
+      cleanedOperationMock.mockImplementation((o: any) => o);
+      mergeOpsMock.mockImplementation((_old: any[], newOps: any[]) => newOps);
+      inferSubOperationsMock.mockReturnValue([]);
+
+      getBridgeApiMock.mockImplementationOnce(() => ({
+        ...defaultBridgeApi(),
+        mapOperationDetailsToExtra: (details: any) => ({
+          assetReference: "hook-wins",
+          hookKey: details.note,
+        }),
+      }));
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        {
+          address,
+          initialAccount: undefined,
+          currency,
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      const operation = result.operations?.[0];
+      expect(operation?.extra).toEqual({
+        assetReference: "hook-wins", // hook's key overrides the adapter's own value on collision
+        assetOwner: "owner", // adapter-only key survives the merge
+        feePayer: address,
+        keptKey: "from-adapter",
+        hookKey: "onchain-detail", // hook-only key, sourced from op.details
+      });
+    });
+
+    test("falls back to the adapter's extra, unmerged, when mapOperationDetailsToExtra throws", async () => {
+      const address = `${currency.id}_addr-hook-err`;
+      const opFromList = {
+        hash: "tx-hash-hook-err",
+        type: "OUT",
+        tx: { failed: false },
+        details: { note: "onchain-detail" },
+      };
+      const adapterExtra = {
+        assetReference: "usdc",
+        assetOwner: "owner",
+        feePayer: address,
+      };
+
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 0n, locked: 0n }]);
+      extractBalanceMock.mockReturnValue({ value: 0n, locked: 0n });
+      listOperationsMock.mockResolvedValue({ items: [opFromList], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 1 });
+      adaptCoreOperationToLiveOperationMock.mockImplementation((_accId, op: any) => ({
+        hash: op.hash,
+        type: op.type,
+        blockHeight: 1,
+        extra: { ...adapterExtra },
+      }));
+      cleanedOperationMock.mockImplementation((o: any) => o);
+      mergeOpsMock.mockImplementation((_old: any[], newOps: any[]) => newOps);
+      inferSubOperationsMock.mockReturnValue([]);
+
+      getBridgeApiMock.mockImplementationOnce(() => ({
+        ...defaultBridgeApi(),
+        mapOperationDetailsToExtra: () => {
+          throw new Error("boom");
+        },
+      }));
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        {
+          address,
+          initialAccount: undefined,
+          currency,
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      const operation = result.operations?.[0];
+      expect(operation?.extra).toEqual(adapterExtra);
+    });
+
     test("buildOneParentOpPerHash: token-only hash produces one synthetic FEES parent with subOperations", async () => {
       const txHash = "pure-erc20-hash";
       const tokenOpFromList = { hash: txHash, type: "OUT", height: 20, tx: { failed: false } };
@@ -1854,6 +1966,42 @@ describe("genericGetAccountShape", () => {
       });
     });
 
+    test("keepFeesOnlyNativeOpType: a standalone zero-net-value OUT op keeps its type instead of collapsing to FEES", async () => {
+      setupSpecTest();
+      getBridgeApiMock.mockImplementationOnce(() => ({
+        ...defaultBridgeApi(),
+        keepFeesOnlyNativeOpType: true,
+      }));
+      listOperationsMock.mockResolvedValue({
+        items: [
+          toCoreOp({
+            type: "OUT",
+            senders: ["address1"],
+            recipients: ["contract1"],
+            value: 0,
+            fee: 1,
+            feesPayer: "address1",
+          }),
+        ],
+        next: undefined,
+      });
+      mockNoSubAccounts();
+      mockNoInferSubOps();
+
+      const result = await runGetShape("address1");
+
+      expect(result).toMatchObject({
+        operations: [
+          {
+            type: "OUT",
+            value: new BigNumber(1),
+            senders: ["address1"],
+            recipients: ["contract1"],
+          },
+        ],
+      });
+    });
+
     test("Case 7: ETH transfer to smart contract", async () => {
       setupSpecTest();
       listOperationsMock.mockResolvedValue({
@@ -2258,6 +2406,133 @@ describe("genericGetAccountShape", () => {
           },
         ],
       });
+    });
+  });
+
+  describe("family account resources", () => {
+    const network = "mainnet";
+    const currency = { id: "some_family", name: "SomeFamily" };
+    const address = "some-address";
+    const fetchAccountResourcesMock = jest.fn();
+
+    beforeEach(() => {
+      getSyncHashMock.mockReturnValue("sync-hash");
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 0n, locked: 0n }]);
+      extractBalanceMock.mockReturnValue({ value: 0n, locked: 0n });
+      listOperationsMock.mockResolvedValue({ items: [], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 0 });
+      mergeOpsMock.mockImplementation((_old: any[], newOps: any[]) => newOps ?? []);
+      cleanedOperationMock.mockImplementation((op: any) => op);
+      inferSubOperationsMock.mockReturnValue([]);
+      chainSpecificGetAccountShapeMock.mockImplementation(() => {});
+      fetchAccountResourcesMock.mockReset();
+    });
+
+    test("spreads whatever key the bridge's fetchAccountResources hook returns, without naming it", async () => {
+      getBridgeApiMock.mockImplementationOnce(() => ({
+        ...defaultBridgeApi(),
+        fetchAccountResources: (...a: any[]) => fetchAccountResourcesMock(...a),
+      }));
+      fetchAccountResourcesMock.mockResolvedValue({
+        someFamilyKey: { a: 1 },
+      });
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        { address, initialAccount: undefined, currency, derivationMode: "" } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(fetchAccountResourcesMock).toHaveBeenCalledWith(currency.id, address);
+      expect((result as any).someFamilyKey).toEqual({ a: 1 });
+    });
+
+    test("adds no extra key when the bridge's fetchAccountResources hook resolves undefined", async () => {
+      getBridgeApiMock.mockImplementationOnce(() => ({
+        ...defaultBridgeApi(),
+        fetchAccountResources: (...a: any[]) => fetchAccountResourcesMock(...a),
+      }));
+      fetchAccountResourcesMock.mockResolvedValue(undefined);
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const resultWithHook = await getShape(
+        { address, initialAccount: undefined, currency, derivationMode: "" } as any,
+        { paginationConfig: {} as any },
+      );
+
+      getBridgeApiMock.mockImplementationOnce(defaultBridgeApi);
+      const resultWithoutHook = await getShape(
+        { address, initialAccount: undefined, currency, derivationMode: "" } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(Object.keys(resultWithHook).sort()).toEqual(Object.keys(resultWithoutHook).sort());
+    });
+
+    test("never calls fetchAccountResources for a bridge that doesn't implement it and adds no extra key", async () => {
+      getBridgeApiMock.mockImplementationOnce(defaultBridgeApi);
+      const otherCurrency = { id: "tezos", name: "Tezos" };
+      const getShape = genericGetAccountShape("mainnet", otherCurrency.id);
+      const result = await getShape(
+        {
+          address: "tz1nohook",
+          initialAccount: undefined,
+          currency: otherCurrency,
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(fetchAccountResourcesMock).not.toHaveBeenCalled();
+      expect("someFamilyKey" in result).toBe(false);
+    });
+
+    test("a family-returned key colliding with a framework field does not overwrite the framework's value", async () => {
+      const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      getBridgeApiMock.mockImplementationOnce(() => ({
+        ...defaultBridgeApi(),
+        fetchAccountResources: (...a: any[]) => fetchAccountResourcesMock(...a),
+      }));
+      // "balance" collides with a framework-owned field; the framework's own BigNumber balance
+      // must win over this bogus family-supplied value.
+      fetchAccountResourcesMock.mockResolvedValue({
+        balance: "bogus-family-value",
+        someFamilyKey: { a: 1 },
+      });
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        { address, initialAccount: undefined, currency, derivationMode: "" } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(result.balance).toEqual(new BigNumber(0));
+      // Non-colliding keys are still spread through.
+      expect((result as any).someFamilyKey).toEqual({ a: 1 });
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    test("reports a colliding key loudly, without throwing", async () => {
+      const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      getBridgeApiMock.mockImplementationOnce(() => ({
+        ...defaultBridgeApi(),
+        fetchAccountResources: (...a: any[]) => fetchAccountResourcesMock(...a),
+      }));
+      fetchAccountResourcesMock.mockResolvedValue({ balance: "bogus-family-value" });
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      await expect(
+        getShape(
+          { address, initialAccount: undefined, currency, derivationMode: "" } as any,
+          { paginationConfig: {} as any },
+        ),
+      ).resolves.toBeDefined();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("balance"));
+
+      consoleErrorSpy.mockRestore();
     });
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
@@ -4,10 +4,15 @@ import { toArray } from "rxjs/operators";
 import { genericSignOperation } from "../signOperation";
 import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getCoinModuleApi } from "../api";
+import { getBridgeApi } from "../bridge";
 import { buildOptimisticOperation } from "../utils";
 
 jest.mock("../api", () => ({
   getCoinModuleApi: jest.fn(),
+}));
+
+jest.mock("../bridge", () => ({
+  getBridgeApi: jest.fn(),
 }));
 
 jest.mock("../utils", () => ({
@@ -48,6 +53,7 @@ describe("genericSignOperation", () => {
     });
 
     (buildOptimisticOperation as jest.Mock).mockReturnValue({ id: "mock-op" });
+    (getBridgeApi as jest.Mock).mockResolvedValue({});
 
     mockSigner.getAddress.mockResolvedValue({ publicKey: "pubKey" });
     mockSigner.signTransaction.mockResolvedValue("sig");
@@ -124,5 +130,47 @@ describe("genericSignOperation", () => {
     const observable = signOperation({ account, transaction: txWithoutFees, deviceId: "" });
 
     await expect(lastValueFrom(observable)).rejects.toThrow(FeeNotLoaded);
+  });
+
+  describe("enrichOptimisticOperation", () => {
+    it("emits the hook's returned operation instead of the pre-hook built operation", async () => {
+      (getBridgeApi as jest.Mock).mockResolvedValue({
+        enrichOptimisticOperation: jest.fn().mockReturnValue({ id: "mock-op", enriched: true }),
+      });
+
+      const signOperation = genericSignOperation("mainnet", "xrp")(mockSignerContext);
+      const observable = signOperation({ account, transaction, deviceId: "" });
+
+      const events = await lastValueFrom(observable.pipe(toArray()));
+
+      expect(events[2]).toEqual({
+        type: "signed",
+        signedOperation: {
+          operation: { id: "mock-op", enriched: true },
+          signature: "signedTx",
+        },
+      });
+    });
+
+    it("falls back to the pre-hook built operation when the hook throws", async () => {
+      (getBridgeApi as jest.Mock).mockResolvedValue({
+        enrichOptimisticOperation: jest.fn().mockImplementation(() => {
+          throw new Error("boom");
+        }),
+      });
+
+      const signOperation = genericSignOperation("mainnet", "xrp")(mockSignerContext);
+      const observable = signOperation({ account, transaction, deviceId: "" });
+
+      const events = await lastValueFrom(observable.pipe(toArray()));
+
+      expect(events[2]).toEqual({
+        type: "signed",
+        signedOperation: {
+          operation: { id: "mock-op" },
+          signature: "signedTx",
+        },
+      });
+    });
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/types.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/types.ts
@@ -44,6 +44,7 @@ export type GasOptionsRaw = {
 export const GENERIC_TRANSACTION_MODE = [
   "send",
   "changeTrust",
+  "token-associate",
   "send-legacy",
   "send-eip1559",
   "delegate",

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -462,6 +462,22 @@ describe("coin-framework utils", () => {
       expect(operation.fee).toEqual(fees);
       expect(operation.value).toEqual(amount);
     });
+
+    it("maps a token-associate transaction to an ASSOCIATE_TOKEN operation", () => {
+      const account = {
+        id: "parent-account-id",
+        freshAddress: "account-address",
+      } as Account;
+      const transaction = {
+        amount: new BigNumber(0),
+        recipient: "",
+        mode: "token-associate",
+      } as GenericTransaction;
+
+      const operation = buildOptimisticOperation(account, transaction);
+
+      expect(operation.type).toBe("ASSOCIATE_TOKEN");
+    });
   });
 
   describe("cleanedOperation", () => {
@@ -659,6 +675,7 @@ describe("coin-framework utils", () => {
         expect(craftTransactionDataMock).not.toHaveBeenCalled();
         expect(defaultCraftTransactionDataSpy).not.toHaveBeenCalled();
       });
+
     });
 
     describe("memo", () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -268,9 +268,15 @@ function isStringArray(value: unknown): value is string[] {
 function isDelegationMode(mode: GenericTransaction["mode"]): mode is StakingOperation {
   return (
     typeof mode === "string" &&
-    ["delegate", "undelegate", "redelegate", "claimReward", "compoundReward", "withdraw"].includes(
-      mode,
-    )
+    [
+      "delegate",
+      "undelegate",
+      "redelegate",
+      "claimReward",
+      "claim-rewards",
+      "compoundReward",
+      "withdraw",
+    ].includes(mode)
   );
 }
 
@@ -681,6 +687,9 @@ export const buildOptimisticOperation = (
   switch (transaction.mode) {
     case "changeTrust":
       type = "OPT_IN";
+      break;
+    case "token-associate":
+      type = "ASSOCIATE_TOKEN";
       break;
     case "delegate":
       type = "DELEGATE";


### PR DESCRIPTION
### 🪜 Stack

Stacked PRs. Merge in order, 1 first — each one targets the branch above it.

1. #33 `feat(ledger-wallet-framework): add family bridge hooks`
2. #34 `feat(generic-coin-framework): add token-associate mode and family hooks`  ← this PR
3. #35 `feat(hedera): migrate to the generic coin framework`
4. #36 `refactor(hedera): rewire the desktop UI onto GenericTransaction`
5. #37 `refactor(hedera): rewire the mobile UI onto GenericTransaction`
6. #38 `test(coin-tester-hedera): add end-to-end coin-tester for hedera`

---

### 📝 Description

Second PR of the Hedera coin-module migration stack. It implements, inside the
generic coin framework, the hooks declared in the previous PR, and adds the
`token-associate` transaction mode.

`utils.ts`
- `token-associate` maps to an `ASSOCIATE_TOKEN` operation.
- `keepFeesOnlyNativeOpType` keeps a fee-only native operation under its own
  type instead of collapsing it to `FEES`.

`getAccountShape.ts`
- Calls `fetchAccountResources` and spreads the result into the account shape.
  Framework-owned keys always win; a colliding key from a family is dropped and
  reported through `console.error`.

`buildSubAccounts.ts`
- Honours the `shouldBuildTokenAccount` veto.

`signOperation.ts`
- Calls `enrichOptimisticOperation` after the generic optimistic operation is
  built.

`accountBridge.ts` / `currencyBridge.ts`
- Pass `receiveAddressMatcher` and `buildIterateResult` through to the wallet
  framework.

`postSync` / sync path
- Applies `mapOperationDetailsToExtra` per operation.

New unit tests cover every hook: `accountBridge`, `currencyBridge`,
`getAccountShape`, `postSync`, `signOperation`, `buildSubAccounts` and `utils`.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-34359
- **ADR** (if any): —
