### PR TITLE
refactor(hedera): rewire the desktop UI onto GenericTransaction (LIVE-34359)

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/hedera/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/AccountBalanceSummaryFooter.tsx
@@ -12,6 +12,7 @@ import InfoCircle from "~/renderer/icons/InfoCircle";
 import ToolTip from "~/renderer/components/Tooltip";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import { useStake } from "LLD/hooks/useStake";
+import { getHederaDelegation } from "@ledgerhq/live-common/families/hedera/delegation";
 import type { HederaFamily } from "./types";
 
 const AccountBalanceSummaryFooter: HederaFamily["AccountBalanceSummaryFooter"] = ({ account }) => {
@@ -20,7 +21,7 @@ const AccountBalanceSummaryFooter: HederaFamily["AccountBalanceSummaryFooter"] =
   const unit = useAccountUnit(account);
   const { getCanStakeCurrency } = useStake();
 
-  if (account.type !== "Account" || !account.hederaResources) {
+  if (account.type !== "Account") {
     return null;
   }
 
@@ -37,7 +38,7 @@ const AccountBalanceSummaryFooter: HederaFamily["AccountBalanceSummaryFooter"] =
     locale,
   };
 
-  const { delegation } = account.hederaResources;
+  const delegation = getHederaDelegation(account);
   const spendableBalance = account.spendableBalance;
   const delegatedAssets = delegation?.delegated ?? new BigNumber(0);
   const claimableRewards = delegation?.pendingReward ?? new BigNumber(0);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/AccountHeaderManageActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/AccountHeaderManageActions.tsx
@@ -22,7 +22,7 @@ const AccountHeaderActions: HederaFamily["accountHeaderManageActions"] = ({
   }
 
   const isStakingEnabled = getCanStakeCurrency(account.currency.id);
-  const isAlreadyStaked = !!account.hederaResources?.delegation;
+  const isAlreadyStaked = (account.stakingPositions?.length ?? 0) > 0;
 
   if (!isStakingEnabled) {
     return [];

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/steps/StepConfirmation.tsx
@@ -1,10 +1,8 @@
-import invariant from "invariant";
 import React, { useEffect } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import { isStakingTransaction } from "@ledgerhq/live-common/families/hedera/utils";
 import { track } from "~/renderer/analytics/segment";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { multiline } from "~/renderer/styles/helpers";
@@ -26,8 +24,7 @@ function StepConfirmation({
   transaction,
   source,
 }: Readonly<StepProps>) {
-  invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
-  const selectedValidatorNodeId = transaction.properties?.stakingNodeId ?? null;
+  const selectedValidatorNodeId = transaction?.valId ? Number(transaction.valId) : null;
 
   useEffect(() => {
     if (optimisticOperation && typeof selectedValidatorNodeId === "number") {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/steps/StepRewards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/steps/StepRewards.tsx
@@ -4,6 +4,7 @@ import { Trans } from "react-i18next";
 import { useSelector } from "LLD/hooks/redux";
 import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/formatCurrencyUnit";
 import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
+import { getHederaDelegation } from "@ledgerhq/live-common/families/hedera/delegation";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import Alert from "~/renderer/components/Alert";
 import Box from "~/renderer/components/Box";
@@ -21,8 +22,8 @@ import type { StepProps } from "../types";
 
 function StepRewards({ account, parentAccount, transaction, status, error }: Readonly<StepProps>) {
   invariant(account && transaction, "hedera: account and transaction required");
-  invariant(account.hederaResources?.delegation, "hedera: delegation is required");
-  const { delegation } = account.hederaResources;
+  const delegation = getHederaDelegation(account);
+  invariant(delegation, "hedera: delegation is required");
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
   const discreet = useDiscreetMode();
   const locale = useSelector(localeSelector);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegatedPositions/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegatedPositions/index.tsx
@@ -9,6 +9,7 @@ import type {
   HederaEnrichedDelegation,
 } from "@ledgerhq/live-common/families/hedera/types";
 import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
+import { getHederaDelegation } from "@ledgerhq/live-common/families/hedera/delegation";
 import { useStake } from "LLD/hooks/useStake";
 import type { TokenAccount } from "@ledgerhq/types-live";
 import { openURL } from "~/renderer/linking";
@@ -92,7 +93,7 @@ const DelegatedPositions = ({ account }: { account: HederaAccount | TokenAccount
     return null;
   }
 
-  const { delegation } = account.hederaResources ?? {};
+  const delegation = getHederaDelegation(account);
   const isStakingEnabled = getCanStakeCurrency(account.currency.id);
 
   if (!isStakingEnabled) {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/Body.tsx
@@ -9,7 +9,10 @@ import type { Account, Operation } from "@ledgerhq/types-live";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import type { HederaAccount, Transaction } from "@ledgerhq/live-common/families/hedera/types";
+import type {
+  HederaAccount,
+  Transaction,
+} from "@ledgerhq/live-common/families/hedera/types";
 import { getDefaultValidator } from "@ledgerhq/live-common/families/hedera/utils";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
@@ -101,9 +104,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
 
       const transaction = bridge.updateTransaction(t, {
         mode: HEDERA_TRANSACTION_MODES.Delegate,
-        properties: {
-          stakingNodeId: defaultValidator?.nodeId ?? null,
-        },
+        valId: defaultValidator ? String(defaultValidator.nodeId) : undefined,
       });
 
       return {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/steps/StepConfirmation.tsx
@@ -1,10 +1,8 @@
-import invariant from "invariant";
 import React, { useEffect } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import { isStakingTransaction } from "@ledgerhq/live-common/families/hedera/utils";
 import { track } from "~/renderer/analytics/segment";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { multiline } from "~/renderer/styles/helpers";
@@ -26,8 +24,7 @@ function StepConfirmation({
   transaction,
   source,
 }: Readonly<StepProps>) {
-  invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
-  const selectedValidatorNodeId = transaction.properties?.stakingNodeId ?? null;
+  const selectedValidatorNodeId = transaction?.valId ? Number(transaction.valId) : null;
 
   useEffect(() => {
     if (optimisticOperation && typeof selectedValidatorNodeId === "number") {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/steps/StepValidator.tsx
@@ -4,7 +4,6 @@ import { Trans } from "react-i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import { HederaValidator, Transaction } from "@ledgerhq/live-common/families/hedera/types";
-import { isStakingTransaction } from "@ledgerhq/live-common/families/hedera/utils";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -20,17 +19,14 @@ export default function StepValidator({
   error,
 }: Readonly<StepProps>) {
   invariant(account && transaction, "hedera: account and transaction required");
-  invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
-  const selectedValidatorNodeId = transaction.properties?.stakingNodeId ?? null;
+  const selectedValidatorNodeId = transaction.valId ? Number(transaction.valId) : null;
   const bridge = useAccountBridge<Transaction>(account, parentAccount);
 
   const updateValidator = (validator: HederaValidator) => {
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         mode: HEDERA_TRANSACTION_MODES.Delegate,
-        properties: {
-          stakingNodeId: validator.nodeId,
-        },
+        valId: String(validator.nodeId),
       });
     });
   };
@@ -65,14 +61,10 @@ export function StepValidatorFooter({
   transaction,
 }: Readonly<StepProps>) {
   invariant(account && transaction, "hedera: account and transaction required");
-  invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
 
   const { errors } = status;
   const canNext =
-    !bridgePending &&
-    !errors.validators &&
-    transaction &&
-    typeof transaction.properties?.stakingNodeId === "number";
+    !bridgePending && !errors.validators && transaction && typeof transaction.valId === "string";
 
   return (
     <Box horizontal>

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/MemoField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/MemoField.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { HEDERA_MAX_MEMO_SIZE } from "@ledgerhq/live-common/families/hedera/constants";
-import { Transaction } from "@ledgerhq/live-common/families/hedera/types";
+import type { Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { track } from "~/renderer/analytics/segment";
 import { SendAmountProps } from "./types";
 import Text from "~/renderer/components/Text";
@@ -19,18 +19,19 @@ const MemoField = ({
   const [memoLength, setMemoLength] = React.useState(0);
   const bridge = useAccountBridge<Transaction>(account);
   const onMemoChange = useCallback(
-    (memo: string) => {
+    (memoValue: string) => {
       track("button_clicked2", {
         ...trackProperties,
         button: "input",
-        memo,
+        memo: memoValue,
       });
       onChange(
         bridge.updateTransaction(transaction, {
-          memo,
+          memoType: memoValue ? "text" : null,
+          memoValue: memoValue || null,
         }),
       );
-      setMemoLength(memo.length);
+      setMemoLength(memoValue.length);
     },
     [trackProperties, onChange, bridge, transaction],
   );
@@ -42,7 +43,7 @@ const MemoField = ({
   return (
     <MemoTagField
       maxLength={HEDERA_MAX_MEMO_SIZE}
-      value={transaction.memo ?? ""}
+      value={transaction.memoValue ?? ""}
       onChange={onMemoChange}
       error={status.errors.transaction}
       CaracterCountComponent={() => (

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/Body.tsx
@@ -175,9 +175,6 @@ const Body = ({
         mode: HEDERA_TRANSACTION_MODES.TokenAssociate,
         assetReference: token.contractAddress,
         assetOwner: mainAccount.freshAddress,
-        properties: {
-          token,
-        },
       };
     },
     [mainAccount],

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/steps/StepAssociationConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/steps/StepAssociationConfirmation.tsx
@@ -1,9 +1,9 @@
-import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
-import { isTokenAssociateTransaction } from "@ledgerhq/live-common/families/hedera/utils";
+import { useFindTokenByAddressInCurrencyQuery } from "@domain/api-currency-token";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import Box from "~/renderer/components/Box";
 import BroadcastErrorDisclaimer from "~/renderer/components/BroadcastErrorDisclaimer";
 import Button from "~/renderer/components/Button";
@@ -28,14 +28,22 @@ const Container = styled(Box).attrs<{
 `;
 
 function StepAssociationConfirmation({
+  account,
   transaction,
   optimisticOperation,
   error,
   signed,
 }: StepProps) {
+  const { data: associatedToken } = useFindTokenByAddressInCurrencyQuery(
+    {
+      contract_address: transaction?.assetReference || "",
+      network: account ? getAccountCurrency(account).id : "",
+    },
+    { skip: !transaction?.assetReference },
+  );
+
   if (optimisticOperation) {
-    invariant(isTokenAssociateTransaction(transaction), "hedera: token associate tx expected");
-    const tokenName = transaction.properties.token.name ?? "token";
+    const tokenName = associatedToken?.name ?? "token";
 
     return (
       <Container>

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/types.ts
@@ -1,4 +1,7 @@
-import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/hedera/types";
+import type {
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/hedera/types";
 import type { Operation } from "@ledgerhq/types-live";
 import type {
   StepProps as DefaultStepProps,

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/Body.tsx
@@ -93,9 +93,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
 
       const transaction = bridge.updateTransaction(t, {
         mode: HEDERA_TRANSACTION_MODES.Redelegate,
-        properties: {
-          stakingNodeId: null,
-        },
+        valId: undefined,
       });
 
       return {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/steps/StepConfirmation.tsx
@@ -1,9 +1,7 @@
-import invariant from "invariant";
 import React, { useEffect } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
-import { isStakingTransaction } from "@ledgerhq/live-common/families/hedera/utils";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import { track } from "~/renderer/analytics/segment";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -26,8 +24,7 @@ function StepConfirmation({
   transaction,
   source,
 }: Readonly<StepProps>) {
-  invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
-  const selectedValidatorNodeId = transaction.properties?.stakingNodeId ?? null;
+  const selectedValidatorNodeId = transaction?.valId ? Number(transaction.valId) : null;
 
   useEffect(() => {
     if (optimisticOperation && typeof selectedValidatorNodeId === "number") {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/steps/StepValidators.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/steps/StepValidators.tsx
@@ -2,11 +2,11 @@ import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
 import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
+import { getHederaDelegation } from "@ledgerhq/live-common/families/hedera/delegation";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import { HederaValidator, Transaction } from "@ledgerhq/live-common/families/hedera/types";
+import type { HederaValidator, Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import { isStakingTransaction } from "@ledgerhq/live-common/families/hedera/utils";
 import { urls } from "~/config/urls";
 import Alert from "~/renderer/components/Alert";
 import Box from "~/renderer/components/Box";
@@ -30,11 +30,10 @@ function StepValidators({
   onUpdateTransaction,
 }: Readonly<StepProps>) {
   invariant(account && transaction, "hedera: account and transaction required");
-  invariant(account.hederaResources?.delegation, "hedera: delegation is required");
-  invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
 
-  const { delegation } = account.hederaResources;
-  const selectedValidatorNodeId = transaction.properties?.stakingNodeId ?? null;
+  const delegation = getHederaDelegation(account);
+  invariant(delegation, "hedera: delegation is required");
+  const selectedValidatorNodeId = transaction.valId ? Number(transaction.valId) : null;
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
   const enrichedDelegation = useHederaEnrichedDelegation(account, delegation);
   const feeError = status.errors.fee;
@@ -47,9 +46,7 @@ function StepValidators({
     onUpdateTransaction(() => {
       return bridge.updateTransaction(transaction, {
         mode: HEDERA_TRANSACTION_MODES.Redelegate,
-        properties: {
-          stakingNodeId: validator.nodeId ?? null,
-        },
+        valId: String(validator.nodeId),
       });
     });
   };

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/Body.tsx
@@ -93,9 +93,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
 
       const transaction = bridge.updateTransaction(t, {
         mode: HEDERA_TRANSACTION_MODES.Undelegate,
-        properties: {
-          stakingNodeId: null,
-        },
+        valId: undefined,
       });
 
       return {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/steps/StepConfirmation.tsx
@@ -1,10 +1,8 @@
-import invariant from "invariant";
 import React, { useEffect } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import { isStakingTransaction } from "@ledgerhq/live-common/families/hedera/utils";
 import { track } from "~/renderer/analytics/segment";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { multiline } from "~/renderer/styles/helpers";
@@ -26,8 +24,7 @@ function StepConfirmation({
   transaction,
   source,
 }: Readonly<StepProps>) {
-  invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
-  const selectedValidatorNodeId = transaction.properties?.stakingNodeId ?? null;
+  const selectedValidatorNodeId = transaction?.valId ? Number(transaction.valId) : null;
 
   useEffect(() => {
     if (optimisticOperation && typeof selectedValidatorNodeId === "number") {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/steps/StepSummary.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Trans } from "react-i18next";
 import invariant from "invariant";
 import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
+import { getHederaDelegation } from "@ledgerhq/live-common/families/hedera/delegation";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { urls } from "~/config/urls";
 import Alert from "~/renderer/components/Alert";
@@ -25,7 +26,7 @@ function StepSummary({
 }: Readonly<StepProps>) {
   invariant(account && transaction, "hedera: account and transaction required");
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
-  const currentValidatorNodeId = account.hederaResources?.delegation?.nodeId;
+  const currentValidatorNodeId = getHederaDelegation(account)?.nodeId;
   const validators = useHederaValidators(account.currency);
   const validator = validators.find(v => v.nodeId === currentValidatorNodeId);
   const isValidatorRemoved = !validator && typeof currentValidatorNodeId === "number";

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/types.ts
@@ -1,8 +1,8 @@
 import type {
   HederaAccount,
-  HederaOperation,
   Transaction,
   TransactionStatus,
+  HederaOperation,
 } from "@ledgerhq/live-common/families/hedera/types";
 import type { Account } from "@ledgerhq/types-live";
 import type { LLDCoinFamily } from "../types";


### PR DESCRIPTION
### 🪜 Stack

Stacked PRs. Merge in order, 1 first — each one targets the branch above it.

1. #33 `feat(ledger-wallet-framework): add family bridge hooks`
2. #34 `feat(generic-coin-framework): add token-associate mode and family hooks`
3. #35 `feat(hedera): migrate to the generic coin framework`
4. #36 `refactor(hedera): rewire the desktop UI onto GenericTransaction`  ← this PR
5. #37 `refactor(hedera): rewire the mobile UI onto GenericTransaction`
6. #38 `test(coin-tester-hedera): add end-to-end coin-tester for hedera`

---

### 📝 Description

Fourth PR of the Hedera coin-module migration stack. It points the desktop
Hedera screens at `GenericTransaction`, the shape the family now produces.

Field renames the UI must follow:
- `transaction.memo` → `memoValue` (plus `memoType`, set to `"text"` or `null`).
- `transaction.stakingNodeId` → `valId`.
- Staking flows read the node id and the delegation from the family helpers
  instead of reading `hederaResources` directly.

Touched flows: send memo field, delegation, redelegation, undelegation, claim
rewards, receive-with-association, the balance summary footer, the delegated
positions list and the account header actions.

No visible behaviour change is intended — this PR only follows the transaction
shape. The user-visible fixes ride in PR 3 of the stack.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-34359
- **ADR** (if any): —
