### PR TITLE
refactor(hedera): rewire the mobile UI onto GenericTransaction (LIVE-34359)

### DIFF
--- a/apps/ledger-live-mobile/src/families/hedera/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AccountBalanceSummaryFooter.tsx
@@ -3,10 +3,10 @@ import type { TFunction } from "i18next";
 import { useTranslation } from "~/context/Locale";
 import { ScrollView } from "react-native";
 import BigNumber from "bignumber.js";
-import invariant from "invariant";
 import CryptoIcon from "@ledgerhq/crypto-icons/native";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { HederaAccount } from "@ledgerhq/live-common/families/hedera/types";
+import { getHederaDelegation } from "@ledgerhq/live-common/families/hedera/delegation";
 import InfoItem from "~/components/BalanceSummaryInfoItem";
 import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
@@ -21,7 +21,6 @@ interface Props {
 type InfoName = "available" | "delegated" | "claimable";
 
 function AccountBalanceSummaryFooter({ account }: Readonly<Props>) {
-  invariant(account.hederaResources, "hedera: hederaResources is missing");
   const { t } = useTranslation();
   const { getCanStakeCurrency } = useStake();
   const [infoName, setInfoName] = useState<InfoName>();
@@ -33,7 +32,7 @@ function AccountBalanceSummaryFooter({ account }: Readonly<Props>) {
   const onPressInfoCreator = useCallback((infoName: InfoName) => () => setInfoName(infoName), []);
 
   const isStakingEnabled = getCanStakeCurrency(account.currency.id);
-  const { delegation } = account.hederaResources;
+  const delegation = getHederaDelegation(account);
   const spendableBalance = account.spendableBalance;
   const delegatedAssets = delegation?.delegated ?? new BigNumber(0);
   const claimableRewards = delegation?.pendingReward ?? new BigNumber(0);
@@ -76,10 +75,6 @@ function AccountBalanceSummaryFooter({ account }: Readonly<Props>) {
 }
 
 export default function AccountBalanceFooter({ account }: Readonly<Props>) {
-  if (!account.hederaResources) {
-    return null;
-  }
-
   return <AccountBalanceSummaryFooter account={account} />;
 }
 

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/02-Summary.tsx
@@ -3,7 +3,7 @@ import { Trans } from "~/context/Locale";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import { Transaction } from "@ledgerhq/live-common/families/hedera/types";
+import type { Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { View, StyleSheet } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
@@ -43,9 +43,6 @@ export default function Summary({ navigation, route }: Props) {
       mode: HEDERA_TRANSACTION_MODES.TokenAssociate,
       assetReference: token.contractAddress,
       assetOwner: mainAccount.freshAddress,
-      properties: {
-        token,
-      },
     } satisfies Partial<Transaction>);
 
     return {

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/types.ts
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/types.ts
@@ -1,4 +1,7 @@
-import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/hedera/types";
+import type {
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/hedera/types";
 import type { Operation } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@domain/entity-currency-token";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";

--- a/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/ValidationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/ValidationSuccess.tsx
@@ -4,7 +4,6 @@ import { StyleSheet, View } from "react-native";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
-import { isStakingTransaction } from "@ledgerhq/live-common/families/hedera/utils";
 import { TrackScreen, track } from "~/analytics";
 import PreventNativeBack from "~/components/PreventNativeBack";
 import ValidateSuccess from "~/components/ValidateSuccess";
@@ -31,9 +30,8 @@ export default function ValidationSuccess({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
 
   const transaction = route.params.transaction;
-  invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
 
-  const selectedValidatorNodeId = transaction.properties?.stakingNodeId ?? null;
+  const selectedValidatorNodeId = transaction.valId ? Number(transaction.valId) : null;
   const source = route.params.source?.name ?? "unknown";
   const delegation = getTrackingDelegationType({ type: route.params.result.type });
   const { ticker } = getAccountCurrency(account);

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/Summary.tsx
@@ -3,13 +3,13 @@ import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import {
-  getDefaultValidator,
-  isStakingTransaction,
-} from "@ledgerhq/live-common/families/hedera/utils";
+import { getDefaultValidator } from "@ledgerhq/live-common/families/hedera/utils";
 import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import type { HederaValidator, Transaction } from "@ledgerhq/live-common/families/hedera/types";
+import type {
+  HederaValidator,
+  Transaction,
+} from "@ledgerhq/live-common/families/hedera/types";
 import type { AccountBridge, AccountLike } from "@ledgerhq/types-live";
 import { Text, Icons } from "@ledgerhq/native-ui";
 import { useTheme } from "@react-navigation/native";
@@ -55,9 +55,7 @@ export default function DelegationSummary({ navigation, route }: Readonly<Props>
 
       const transaction = bridge.updateTransaction(t, {
         mode: HEDERA_TRANSACTION_MODES.Delegate,
-        properties: {
-          stakingNodeId: defaultValidator?.nodeId ?? null,
-        },
+        valId: defaultValidator ? String(defaultValidator.nodeId) : undefined,
       });
 
       return {
@@ -68,7 +66,6 @@ export default function DelegationSummary({ navigation, route }: Readonly<Props>
     });
 
   invariant(transaction, "transaction must be defined");
-  invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
 
   const { rotate, resetRotation } = useChangeValidatorRotateAnim();
 
@@ -89,7 +86,7 @@ export default function DelegationSummary({ navigation, route }: Readonly<Props>
 
   const currency = getAccountCurrency(account);
   const color = getCurrencyColor(currency);
-  const selectedValidatorNodeId = transaction.properties?.stakingNodeId ?? null;
+  const selectedValidatorNodeId = transaction.valId ? Number(transaction.valId) : null;
   const selectedValidator =
     validators.find(v => v.nodeId === selectedValidatorNodeId) ?? defaultValidator ?? undefined;
   const hasErrors = Object.keys(status.errors).length > 0;
@@ -103,9 +100,7 @@ export default function DelegationSummary({ navigation, route }: Readonly<Props>
       return {
         ...prev,
         mode: HEDERA_TRANSACTION_MODES.Delegate,
-        properties: {
-          stakingNodeId: validator?.nodeId ?? null,
-        },
+        valId: validator ? String(validator.nodeId) : undefined,
       };
     });
   }, [updateTransaction, defaultValidator, route.params]);

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/ValidationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/ValidationSuccess.tsx
@@ -5,7 +5,6 @@ import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import { isStakingTransaction } from "@ledgerhq/live-common/families/hedera/utils";
 import { TrackScreen, track } from "~/analytics";
 import PreventNativeBack from "~/components/PreventNativeBack";
 import ValidateSuccess from "~/components/ValidateSuccess";
@@ -29,9 +28,8 @@ export default function ValidationSuccess({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
 
   const transaction = route.params.transaction;
-  invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
 
-  const selectedValidatorNodeId = transaction.properties?.stakingNodeId ?? null;
+  const selectedValidatorNodeId = transaction.valId ? Number(transaction.valId) : null;
   const source = route.params.source?.name ?? "unknown";
   const delegation = getTrackingDelegationType({ type: route.params.result.type });
   const { ticker } = getAccountCurrency(account);

--- a/apps/ledger-live-mobile/src/families/hedera/Delegations/DelegationPlaceholder.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/Delegations/DelegationPlaceholder.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export default function DelegationPlaceholder({ account }: Readonly<Props>) {
-  invariant(!account.hederaResources?.delegation, "hedera: account shouldn't have delegation");
+  invariant(!account.stakingPositions?.length, "hedera: account shouldn't have delegation");
   const { t } = useTranslation();
   const navigation = useNavigation();
 

--- a/apps/ledger-live-mobile/src/families/hedera/Delegations/index.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/Delegations/index.tsx
@@ -12,6 +12,7 @@ import { getAddressExplorer, getDefaultExplorerView } from "@ledgerhq/live-commo
 import type { HederaAccount, HederaDelegation } from "@ledgerhq/live-common/families/hedera/types";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
+import { getHederaDelegation } from "@ledgerhq/live-common/families/hedera/delegation";
 import type { AccountLike, TokenAccount } from "@ledgerhq/types-live";
 import { Box, Flex, Text } from "@ledgerhq/native-ui";
 import AccountSectionLabel from "~/components/AccountSectionLabel";
@@ -299,18 +300,20 @@ export default function HederaDelegations({ account }: Readonly<{ account: Accou
     return null;
   }
 
-  if (!hederaAccount.hederaResources) {
-    return null;
-  }
+  const delegation = getHederaDelegation(hederaAccount);
 
-  if (!hederaAccount?.hederaResources.delegation) {
+  if (!delegation) {
     return <DelegationPlaceholder account={hederaAccount} />;
   }
 
   return (
     <Delegations
       account={hederaAccount}
-      delegatedPosition={hederaAccount.hederaResources.delegation}
+      delegatedPosition={{
+        nodeId: delegation.nodeId,
+        delegated: delegation.delegated,
+        pendingReward: delegation.pendingReward,
+      }}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/families/hedera/EditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/EditMemo.tsx
@@ -21,7 +21,7 @@ type NavigationProps = BaseComposite<
 function HederaEditMemo({ navigation, route }: NavigationProps) {
   const { colors } = useTheme();
   const { t } = useTranslation();
-  const [memo, setMemo] = useState(route.params.transaction.memo);
+  const [memo, setMemo] = useState(route.params.transaction.memoValue ?? undefined);
   const account = route.params.account;
   const bridge = useAccountBridge<HederaTransaction>(account);
   const onValidateText = useCallback(() => {
@@ -29,7 +29,8 @@ function HederaEditMemo({ navigation, route }: NavigationProps) {
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,
       transaction: bridge.updateTransaction(transaction, {
-        memo,
+        memoType: memo ? "text" : null,
+        memoValue: memo || null,
       }),
     });
   }, [navigation, route.params, account, bridge, memo]);

--- a/apps/ledger-live-mobile/src/families/hedera/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/MemoTagInput.tsx
@@ -7,6 +7,10 @@ import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemo
 export default (props: MemoTagInputProps<HederaTransaction>) => (
   <GenericMemoTagInput
     {...props}
-    valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
+    valueToTxPatch={value => tx => ({
+      ...tx,
+      memoType: value ? "text" : null,
+      memoValue: value || null,
+    })}
   />
 );

--- a/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/Amount.tsx
@@ -42,9 +42,7 @@ function RedelegationAmount({ navigation, route }: Props) {
 
     const transaction = bridge.updateTransaction(t, {
       mode: HEDERA_TRANSACTION_MODES.Redelegate,
-      properties: {
-        stakingNodeId: route.params.selectedValidator.nodeId,
-      } as const,
+      valId: String(route.params.selectedValidator.nodeId),
     });
 
     return {

--- a/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/ValidationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/ValidationSuccess.tsx
@@ -5,7 +5,6 @@ import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import { isStakingTransaction } from "@ledgerhq/live-common/families/hedera/utils";
 import { TrackScreen, track } from "~/analytics";
 import PreventNativeBack from "~/components/PreventNativeBack";
 import ValidateSuccess from "~/components/ValidateSuccess";
@@ -32,9 +31,8 @@ export default function ValidationSuccess({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
 
   const transaction = route.params.transaction;
-  invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
 
-  const selectedValidatorNodeId = transaction.properties?.stakingNodeId ?? null;
+  const selectedValidatorNodeId = transaction.valId ? Number(transaction.valId) : null;
   const source = route.params.source?.name ?? "unknown";
   const delegation = getTrackingDelegationType({ type: route.params.result.type });
   const { ticker } = getAccountCurrency(account);

--- a/apps/ledger-live-mobile/src/families/hedera/SendRowsCustom.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/SendRowsCustom.tsx
@@ -42,7 +42,7 @@ export default function HederaSendRowsCustom(props: Props) {
   return (
     <View>
       <SummaryRow title={t("send.summary.memo.title")} onPress={editMemo}>
-        {transaction.memo ? (
+        {transaction.memoValue ? (
           <LText
             semiBold
             style={styles.tagText}
@@ -50,7 +50,7 @@ export default function HederaSendRowsCustom(props: Props) {
             numberOfLines={1}
             testID="summary-memo-tag"
           >
-            {transaction.memo}
+            {transaction.memoValue}
           </LText>
         ) : (
           <LText

--- a/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/Amount.tsx
@@ -42,9 +42,7 @@ function UndelegationAmount({ navigation, route }: Props) {
 
     const transaction = bridge.updateTransaction(t, {
       mode: HEDERA_TRANSACTION_MODES.Undelegate,
-      properties: {
-        stakingNodeId: null,
-      },
+      valId: undefined,
     });
 
     return {

--- a/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/ValidationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/ValidationSuccess.tsx
@@ -5,7 +5,6 @@ import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import { isStakingTransaction } from "@ledgerhq/live-common/families/hedera/utils";
 import { TrackScreen, track } from "~/analytics";
 import PreventNativeBack from "~/components/PreventNativeBack";
 import ValidateSuccess from "~/components/ValidateSuccess";
@@ -33,9 +32,8 @@ export default function ValidationSuccess({ navigation, route }: Props) {
 
   const transaction = route.params.transaction;
   invariant(account, "account must be defined");
-  invariant(isStakingTransaction(transaction), "hedera: staking tx expected");
 
-  const selectedValidatorNodeId = transaction.properties?.stakingNodeId ?? null;
+  const selectedValidatorNodeId = transaction.valId ? Number(transaction.valId) : null;
   const source = route.params.source?.name ?? "unknown";
   const delegation = getTrackingDelegationType({ type: route.params.result.type });
   const { ticker } = getAccountCurrency(account);

--- a/apps/ledger-live-mobile/src/families/hedera/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/accountActions.tsx
@@ -22,7 +22,7 @@ const getMainActions = ({
   const currency = getAccountCurrency(account);
   const label = getStakeLabelLocaleBased();
   const hasNoFunds = account.spendableBalance.isZero();
-  const isAlreadyDelegated = !!account.hederaResources?.delegation;
+  const isAlreadyDelegated = (account.stakingPositions?.length ?? 0) > 0;
 
   const navigationParams: NavigationParamsType = (() => {
     if (isAlreadyDelegated) {


### PR DESCRIPTION
### 🪜 Stack

Stacked PRs. Merge in order, 1 first — each one targets the branch above it.

1. #33 `feat(ledger-wallet-framework): add family bridge hooks`
2. #34 `feat(generic-coin-framework): add token-associate mode and family hooks`
3. #35 `feat(hedera): migrate to the generic coin framework`
4. #36 `refactor(hedera): rewire the desktop UI onto GenericTransaction`
5. #37 `refactor(hedera): rewire the mobile UI onto GenericTransaction`  ← this PR
6. #38 `test(coin-tester-hedera): add end-to-end coin-tester for hedera`

---

### 📝 Description

Fifth PR of the Hedera coin-module migration stack. Same change as the desktop
PR, applied to the mobile Hedera screens.

Field renames the UI must follow:
- `transaction.memo` → `memoValue` (plus `memoType`).
- `transaction.stakingNodeId` → `valId`.
- Delegation data comes from the family helpers, not from `hederaResources`.

Touched flows: memo tag input and edit-memo, send rows, associate-token,
delegation, redelegation, undelegation, claim rewards, the delegations list and
placeholder, the balance summary footer and the account actions.

No visible behaviour change is intended — this PR only follows the transaction
shape.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-34359
- **ADR** (if any): —
