### PR TITLE
test(coin-tester-hedera): add end-to-end coin-tester for hedera (LIVE-34359)

### DIFF
--- a/.changeset/coin-tester-hedera-poc.md
+++ b/.changeset/coin-tester-hedera-poc.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": patch
+---
+
+Support overriding the consensus node topology via `HederaConfig.consensusNodes`, for pointing the SDK at a local network without changing mainnet/testnet behavior.

--- a/.github/workflows/test-coin-tester.yml
+++ b/.github/workflows/test-coin-tester.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 env:
-  COIN_TESTER_CURRENCIES: "evm polkadot solana bitcoin tezos tron xrp stellar multiversx cosmos cardano vechain near"
+  COIN_TESTER_CURRENCIES: "evm polkadot solana bitcoin tezos tron xrp stellar multiversx cosmos cardano vechain near hedera"
 
 jobs:
   is-affected:
@@ -111,7 +111,7 @@ jobs:
     name: Coin Tester - ${{ matrix.chain }}
     needs: is-affected
     if: ${{ needs.is-affected.outputs.is-affected == 'true' }}
-    runs-on: public-ledgerhq-shared-small
+    runs-on: ledger-live-linux-8CPU-32RAM
     permissions:
       id-token: write
       contents: read

--- a/libs/coin-tester-modules/README.md
+++ b/libs/coin-tester-modules/README.md
@@ -20,6 +20,7 @@ A workspace directory of coin-specific end-to-end test packages for Ledger Live.
 | `@ledgerhq/coin-tester-cardano` | Cardano |
 | `@ledgerhq/coin-tester-cosmos` | Cosmos |
 | `@ledgerhq/coin-tester-evm` | EVM chains (Ethereum, etc.) |
+| `@ledgerhq/coin-tester-hedera` | Hedera (HBAR) |
 | `@ledgerhq/coin-tester-polkadot` | Polkadot |
 | `@ledgerhq/coin-tester-solana` | Solana |
 | `@ledgerhq/coin-tester-stellar` | Stellar |

--- a/libs/coin-tester-modules/coin-tester-hedera/README.md
+++ b/libs/coin-tester-modules/coin-tester-hedera/README.md
@@ -1,0 +1,266 @@
+# @ledgerhq/coin-tester-hedera
+
+End-to-end coin-tester scenarios for the **legacy** `@ledgerhq/coin-hedera` bridge: sync → craft →
+status → sign → broadcast → re-sync → assert, against a real local Hedera network, signing with a
+pure-software Ed25519 key (no Speculos, no device).
+
+## Scope
+
+Five scenarios, each on its own account funded from the genesis operator (`0.0.2`), all sharing a
+single Solo deployment, plus a bridge-level negative-cases block:
+
+1. **Native HBAR sends** (`scenarii/hedera.ts`) — send 1 HBAR to an existing recipient; send 1 HBAR
+   with a memo (asserts the memo round-trips through sync); send to a never-funded ED25519 alias to
+   exercise Hedera's auto-account-creation; send max (drains the account).
+2. **HTS association and transfer** (`scenarii/hederaToken.ts`) — associate a locally minted
+   fungible token through the bridge, inject a treasury transfer, then send part of the balance to
+   a separate, pre-associated fixture account, and finally send max (drains the sub-account).
+3. **Delegate and undelegate** (`scenarii/hederaStaking.ts`) — stake to Solo's consensus node, then
+   unstake.
+4. **Multiple HTS tokens via auto-association** (`scenarii/hederaMultiToken.ts`) — two tokens land
+   on the account via auto-association (no explicit `associate` transaction), then a plain HBAR send
+   is asserted to leave both token sub-accounts untouched.
+5. **ERC20 transfer** (`scenarii/hederaErc20.ts`) — deploy `LedgerLiveTestToken` (see "The ERC20
+   contract artifact" below), seed the account under test directly from the genesis operator, then
+   send part of the balance through the bridge. See "ERC20 coverage" below for exactly what this
+   asserts and what it doesn't — **this scenario has never been run in this environment** (no
+   Kubernetes cluster available here); it is unexercised pending a cluster run.
+
+All five sign with a pure-software Ed25519 key (no Speculos, no device) and follow the same loop:
+sync → craft → status → sign → broadcast → re-sync → assert.
+
+On top of the scenarios, `src/negativeCases.ts` (`describeNegativeCases()`, wired into the same
+`describe("Hedera")` in `scenarii.test.ts`) asserts directly against `getTransactionStatus` —
+without broadcasting — for cases a broadcast-based scenario can't cover: insufficient HBAR balance,
+a malformed recipient accountId, an HTS transfer to an unassociated recipient (warning), an HTS
+transfer above the held token balance, and (in a nested `describe("erc20 negative cases")`, its own
+Solo contract deploy and its own msw server) an ERC20 transfer above the held token balance. That
+nested block registers both an HTS token and an ERC20 token on the same account, which exercises
+the `[...mirrorTokens, ...erc20Tokens]` merge in `coin-hedera/src/bridge/utils.ts` — an account
+holding both kinds of token simultaneously is constructed there, but nothing in that block asserts
+on the merge itself.
+
+Out of scope (deferred): `ClaimRewards`, memo edge cases, and making `coin-hedera`'s hgraph
+dependency optional. CI wiring is now partially done — see "CI" below.
+
+## Running locally
+
+Requires a Kubernetes >= v1.32.2 capable host (kind + kubectl + helm). Hiero Solo
+(`@hiero-ledger/solo`) deploys a single-node cluster running the consensus node, mirror node,
+JSON-RPC relay and explorer all as pods inside one container. Under Solo 0.83's small-memory profile
+a full run peaks around ~4 GB RAM (measured on the local suite: kind container ~3.8 GiB RSS,
+consensus-node Java heap capped at 256M, kube-apiserver at 300Mi); budget ~6 GB free for headroom.
+The small-memory profile is on by default and passing `--values-file` would disable it, so don't.
+
+```bash
+pnpm coin:tester:hedera start
+```
+
+Cold start is ~7–10 minutes. That budget is split in two: cluster bring-up runs in the suite's
+`beforeAll` under its own `CLUSTER_BRING_UP_TIMEOUT_MS` (15 minutes), separate from the per-test
+`jest.setTimeout(360_000)` (6 minutes) — deploy is no longer inside a test, so a hung scenario now
+fails in 6 minutes instead of being charged against, or hidden by, the cluster's own budget.
+`teardown` runs unconditionally after every run (deploy + destroy every time — no persistence, by
+design, to match every other coin-tester package in this workspace).
+
+The cluster is brought up once in the suite's `beforeAll` and torn down in its `afterAll`. No
+scenario (and no negative case) may tear it down — doing so would leave the remaining scenarios
+talking to a deleted pod.
+
+## Solo's undeclared `reflect-metadata` and `protobufjs` dependencies
+
+Solo bare-imports `reflect-metadata` in its `dist/src/index.js` (it needs the polyfill for
+`tsyringe-neo`'s decorator-based DI), but **no published version declares it** — 0.57.0 through
+0.83.0 all omit it from `dependencies`, `peerDependencies` and `optionalDependencies`, and
+`tsyringe-neo` doesn't pull it in either. It only works upstream because flat npm/yarn layouts hoist
+it. Under pnpm's strict layout Solo fails immediately with `ERR_MODULE_NOT_FOUND: reflect-metadata`,
+before it ever reaches the cluster. `protobufjs` has the same undeclared-dependency shape (a
+transitive Solo/Hedera-SDK need that isn't in anyone's manifest) and fails the same way under pnpm's
+strict layout, so it gets the same treatment.
+
+The fix is a `pnpm.packageExtensions` entry in the **root `package.json`**, declaring both
+dependencies on Solo's behalf:
+
+```json
+"@hiero-ledger/solo": {
+  "dependencies": {
+    "reflect-metadata": "^0.2.2",
+    "protobufjs": "^8.0.1"
+  }
+}
+```
+
+Notes for whoever touches this next:
+
+- The key is deliberately **unversioned**. Every published version is affected, so pinning it to one
+  (e.g. `@hiero-ledger/solo@0.68.0`) would make the extension silently stop applying on the next
+  bump, reproducing the original error with no clue as to why.
+- Root `package.json` already has a `packageExtensions` block — merge into it. Adding a second key
+  of the same name is silently discarded by JSON's last-key-wins semantics.
+- After editing, `rm -rf node_modules/.pnpm/@hiero-ledger+solo*` and `pnpm install --force`. A plain
+  `pnpm install` reports "Lockfile is up to date" and skips re-resolving the extension.
+
+Every failure mode above is silent, which is what makes this expensive to rediscover. The upstream
+fix is a one-liner in Solo's own `package.json`; once it lands, this entry can be dropped.
+
+## Solo leaks its port-forwards
+
+Solo exposes the consensus node (`35211`) and mirror node (`38081`) with `--force-port-forward`,
+spawning `persist-port-forward.js` / `kubectl port-forward` as **detached** processes. `solo one-shot
+falcon destroy` tears down cluster resources only, and jest's `--forceExit` can't reach them either —
+they survive every run, including green ones, reparented to init.
+
+Left alone they don't just occupy the ports: the next run can connect to a tunnel pointing at a
+deleted pod and time out, which reads as a Hedera/consensus-node failure rather than as leftover
+state. That misdiagnosis is expensive.
+
+`solo.ts` calls `killPortForwards()` **only after `destroy`**, not before `deploy` — deliberately.
+Like every sibling coin-tester, bring-up only starts things; teardown is where cleanup lives. A
+SIGKILL/OOM/power-loss run bypasses `teardownSolo()` entirely and can leave both the deployment and
+its port-forwards behind; recover by hand with
+`solo one-shot falcon destroy --deployment coin-tester-hedera` (this also clears the namespace so
+the next `deploy --quiet-mode` doesn't reject it). `killPortForwards()` itself is best-effort and
+namespace-scoped — see the comments in `solo.ts` for why it targets `pgrep`/`kill` rather than the
+more obvious `pkill -f`. It is a no-op on Windows; clean up by hand there if the next run can't bind.
+Arguably Solo's own `destroy` should do this — the same "worth an upstream issue" caveat as
+`reflect-metadata` above.
+
+## The hgraph limitation
+
+`coin-hedera` calls the closed-source, commercial `hgraph.io` GraphQL indexer unconditionally on
+every sync (`getERC20BalancesForAccountV2`, `getLatestIndexedConsensusTimestamp`). hgraph has no
+open-source server and cannot be booted locally, so this package mocks it via MSW (`src/indexer.ts`)
+rather than hitting a real instance. The mock is an *observer*, not a hard assertion on hgraph's
+query shape — asserting that shape would couple this tester to `coin-hedera`'s internal query
+pattern. `indexer.ts` routes each request on `body.variables` (each of the three queries the fake
+answers has a distinguishable shape) and then cross-checks the chosen branch against the query
+text itself, so a routing/variables mismatch fails loudly instead of silently answering the wrong
+query. The negative guarantee ("nothing external but the fake hgraph is hit") comes from the MSW
+`onUnhandledRequest` throwing on any non-local, non-hgraph request — narrowed specifically to the
+local mirror-node port (`LOCAL_MIRROR_NODE_PORT`), not all of localhost, so no other local traffic
+is waved through unnoticed.
+
+Making hgraph optional in `coin-hedera` itself (so this mock is unnecessary) is a separate,
+deferred change — see the PR description for scope.
+
+## The stateful hgraph fake
+
+`src/hgraphFake.ts` doesn't invent data: it translates real responses from the Solo mirror node
+into the hgraph GraphQL response shapes `coin-hedera` consumes, so the ERC20 scenario and negative
+case are backed by an actual local network rather than fixed fixtures. It answers the three
+queries `coin-hedera` sends, each on a different refresh model:
+
+- **`erc_token_account` (balances) — live on every query.** `getErcTokenAccountRows` calls the
+  mirror node's `/api/v1/contracts/call` (`balanceOf`) directly, once per registered token, on
+  every request. No caching, no snapshot.
+- **`erc_token_transfer` — a snapshot taken in `refresh()`.** `refresh()` re-scans every top-level
+  `CONTRACTCALL` transaction from the mirror node, joins each to its logs, and decodes `Transfer`
+  events into a frozen, sorted array (`transferSnapshot`). `getErcTokenTransferRows` only ever
+  filters and paginates that frozen array — it never talks to the network itself. `refresh()` is
+  called from the ERC20 scenario's `beforeSync` (which runs inside `executeScenario`'s retry loop,
+  so a not-yet-indexed transfer gets picked up on a later attempt) and, in the negative-case block,
+  explicitly before the manual sync since no `beforeSync` hook exists there.
+- **`ethereum_transaction` (latest indexed timestamp) — live, with a floor.**
+  `getLatestEthereumTransactionTimestamp` reads the mirror node's latest contract result and
+  returns `max(that timestamp, wall clock)`. The floor exists because three scenarios — `hedera`,
+  `hedera token` and `hedera staking` — share one Solo cluster and run *before* any ERC20 contract
+  exists. Without it, `GET /api/v1/contracts/results?limit=1&order=desc` would return an empty
+  list, and `coin-hedera`'s `getLatestIndexedConsensusTimestamp` would hit
+  `invariant(..., "No transactions found in Hgraph")`, capsizing those three otherwise-green
+  scenarios. The wall-clock floor also keeps the value from ever answering with a timestamp behind
+  a call just made.
+
+### A known `coin-hedera` pagination bug, deliberately reproduced rather than fixed
+
+`getERC20Transfers` always calls with `fetchAllPages: true` and no explicit `order`, so
+`getPaginationDirection(true, "desc")` returns `_gt` unconditionally while the query is actually
+sorted `desc` — the cursor advances backwards through a `> cursor` filter, walking *away* from the
+rows it should be paging into. For an account with more than 100 ERC20 transfers, that mismatch
+would make the real client's pagination loop repeat the same page forever; the only thing that
+would end it is a page short enough to look like the end of the data. This is a real bug in
+`coin-hedera`, out of scope for this tester to fix (Global Constraint 1) — `hgraphFake.ts`
+reproduces the real hgraph contract faithfully (`> cursor`, sorted desc, sliced to `limit`) rather
+than defending against the caller's own `_gt`/`desc` mismatch. To keep that fidelity from turning
+into a genuine infinite loop under test, the fake carries its own page counter
+(`MAX_TRANSFER_PAGES`, reset by `refresh()`) and throws a named `HgraphFakeGuardError` after 50
+pages — converting a hang into a diagnosable failure instead of a 6-minute Jest timeout with no
+clue why.
+
+## The ERC20 contract artifact
+
+`src/fixtures/LedgerLiveTestToken.json` is committed **compiled-only** — bytecode and ABI, no
+`.sol` file anywhere in the repo. A Solidity source file that CI never compiles would silently
+drift from the bytecode sitting next to it, which is worse than not having the source checked in
+at all. The full source and the exact `solc` invocation used to produce the artifact
+(`solc-js 0.8.36`, `--optimize --bin --abi`) live in the artifact's own `origin` field, so
+refreshing it is a matter of pasting that source into a `.sol` file and re-running the documented
+command. The contract itself is deliberately minimal (`transfer`/`balanceOf`/`Transfer` event only,
+no pause/owner/blacklist hooks) so nothing in it can fire unpredictably against the bridge under
+test.
+
+## ERC20 coverage
+
+ERC20 support landed in this tester, but **it has never been run against a real Solo cluster in
+this environment** — there is no Kubernetes host available here, so the ERC20 scenario
+(`scenarii/hederaErc20.ts`) and the ERC20 negative case (`negativeCases.ts`'s
+`describe("erc20 negative cases")`) are, as of this writing, unexercised beyond the unit tests
+(`hgraphFake.test.ts`, `indexer.test.ts`) that don't need a cluster. Anyone picking this up should
+run `pnpm coin:tester:hedera start` on a k8s-capable host before trusting that the scenario passes.
+
+What the code does, honestly stated:
+
+- **HTS — unchanged.** Association, send, send-max, multi-token auto-association, and the HTS
+  negative cases all predate this work and are untouched by it.
+- **ERC20 — covered by the new scenario and negative case:** contract deploy
+  (`deployErc20Token`), seeding a balance from the genesis operator, a bridge-level send, the fee
+  landing as its own `FEES` operation (ERC20 has no HTS equivalent — a plain HBAR-value transfer
+  has none), balance validation (the ERC20 negative case), and a gas-estimate sanity check via an
+  `extra.gasLimit` sentinel assertion (asserted `!= DEFAULT_GAS_LIMIT` and `> 0`, not against an
+  upper bound — Solo's real intrinsic-cost overhead on top of the estimate is unmeasured).
+- **Constructed but not asserted on:** the ERC20 negative-case block registers both an HTS token
+  and an ERC20 token on the same account, which exercises the `[...mirrorTokens, ...erc20Tokens]`
+  merge in `coin-hedera/src/bridge/utils.ts` (an account holding both kinds of token
+  simultaneously) — but nothing in that block asserts anything about the merged result itself.
+- **Still uncovered:** ERC20 send-max, a third party receiving an ERC20 transfer with no
+  operations of its own on the account under test, and hgraph pagination beyond 100 transfers (see
+  the pagination bug above).
+
+## Unit tests for the harness itself
+
+Unlike every sibling coin-tester, this package ships unit tests for its own harness:
+`signer.test.ts`, `indexer.test.ts`, `solo.test.ts`, `fixtures.test.ts` and `hgraphFake.test.ts`.
+The first two exist because the SDK's public-key encoding and the hgraph `invariant` are both
+silent-failure modes that would otherwise only surface deep inside a 10-minute scenario run.
+`solo.test.ts` guards `deploySolo()`'s memoisation, whose regression costs about 20 extra minutes
+per run instead of failing loudly. `hgraphFake.test.ts` is the main non-cluster guarantee for the
+whole ERC20 feature: it exercises the mirror-node → hgraph mapping directly — cursor slicing,
+long-zero address decoding, zero-address mint/burn handling, and the `ethereum_transaction`
+floor — all wrong-not-loud failure modes that would otherwise only show up as a confusing scenario
+failure minutes into a cluster run. `pnpm start`'s `src/*.test.ts` glob picks them all up alongside
+the scenario.
+
+## CI
+
+`hedera` is listed in `.github/workflows/test-coin-tester.yml`'s `COIN_TESTER_CURRENCIES`, so it
+enters the matrix. The whole `coin-tester` job moved from `public-ledgerhq-shared-small` to
+`ledger-live-linux-8CPU-32RAM`, because the Hedera leg brings up a local kind cluster that the shared
+small runner cannot host (~4 GB RAM peak, see "Running locally" above).
+
+No tooling-install step is needed, and adding one would be wasted work: Solo ships a
+`DependencyManager` per binary (`dist/src/core/dependency-managers/` covers kubectl, kind, helm,
+crane, podman) and resolves each one in the order *its own `~/.solo/bin`* → *`PATH`, but only if the
+version matches what Solo pins* → *download from the upstream release URL*. A pre-installed binary of
+the wrong version is simply ignored and re-downloaded, so `helm/kind-action` and friends buy nothing.
+What the runner **does** have to provide is a working container engine (Docker or Podman) for kind to
+create the cluster in — that is an image-level prerequisite, not something a workflow step can fix.
+
+The job still sets `continue-on-error: true`, so a red Hedera leg won't block a PR while this is
+being shaken out.
+
+Note that the matrix filter matches chains with `grep -qw "$coin"` against the affected paths. Since
+`-` is not a word character, `hedera` matches every `libs/coin-modules/coin-hedera/**` path, so any
+change to the coin module schedules this leg. That is intended: the tester exists to guard exactly
+those changes.
+
+`pnpm coin:tester:hedera start` on a suitable local host remains the fastest way to iterate without
+waiting on CI.

--- a/libs/coin-tester-modules/coin-tester-hedera/jest.config.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/jest.config.ts
@@ -1,0 +1,36 @@
+import type { Config } from "jest";
+
+// Shaped like the sibling coin-testers (e.g. coin-tester-cosmos). The load-bearing option is the
+// `@ledgerhq/source` export condition: it resolves workspace @ledgerhq/* packages — notably
+// @ledgerhq/coin-hedera and @ledgerhq/live-common — from their TypeScript SOURCE, so this tester
+// exercises current source without a prior `pnpm build` of lib/.
+const config: Config = {
+  testEnvironment: "node",
+  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup"],
+  testEnvironmentOptions: {
+    customExportConditions: ["@ledgerhq/source", "node", "require", "default"],
+  },
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  // @ledgerhq packages resolve to their TS source (via the condition above), so swc must transform
+  // them even inside node_modules; everything else there stays ignored.
+  transformIgnorePatterns: ["/node_modules/.pnpm/(?!@ledgerhq\\+)"],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  // @ledgerhq sources use ESM ".js" specifiers on ".ts" files; strip the extension so jest resolves
+  // the TypeScript source.
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"],
+  reporters: ["default", ...(process.env.CI ? ["github-actions"] : [])],
+};
+
+export default config;

--- a/libs/coin-tester-modules/coin-tester-hedera/package.json
+++ b/libs/coin-tester-modules/coin-tester-hedera/package.json
@@ -1,0 +1,82 @@
+{
+  "name": "@ledgerhq/coin-tester-hedera",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Ledger Hedera Coin Tester",
+  "main": "src/scenarii.test.ts",
+  "keywords": [
+    "Ledger",
+    "LedgerWallet",
+    "Hedera",
+    "HBAR",
+    "Testing"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LedgerHQ/ledger-live.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LedgerHQ/ledger-live/issues"
+  },
+  "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/coin-tester-modules/coin-tester-hedera",
+  "typesVersions": {
+    "*": {
+      "lib/*": [
+        "lib/*"
+      ],
+      "lib-es/*": [
+        "lib-es/*"
+      ],
+      "*": [
+        "lib/*"
+      ]
+    }
+  },
+  "exports": {
+    "./lib/*": "./lib/*.js",
+    "./lib-es/*": "./lib-es/*.js",
+    "./package.json": "./package.json"
+  },
+  "license": "Apache-2.0",
+  "scripts": {
+    "clean": "rimraf lib lib-es",
+    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "prewatch": "pnpm build",
+    "watch": "tsc --watch --project tsconfig.build.json",
+    "watch:es": "tsc --watch --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "lint": "oxlint src",
+    "lint:fix": "oxfmt src && oxlint src --fix --quiet",
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "typecheck": "tsc --noEmit --customConditions node",
+    "knip-check": "pnpm knip --directory ../../.. -W libs/coin-tester-modules/coin-tester-hedera",
+    "start": "pnpm jest --runTestsByPath src/*.test.ts --runInBand --forceExit"
+  },
+  "dependencies": {
+    "@hashgraph/sdk": "2.78.0",
+    "@ledgerhq/coin-hedera": "workspace:^",
+    "@ledgerhq/coin-tester": "workspace:^",
+    "@ledgerhq/ledger-wallet-framework": "workspace:^",
+    "@ledgerhq/live-common": "workspace:^",
+    "@ledgerhq/live-config": "workspace:^",
+    
+    "@ledgerhq/types-live": "workspace:^",
+    "bignumber.js": "^9.1.2",
+    "chalk": "^4.1.2",
+    "msw": "catalog:",
+    "viem": "^2.27.0"
+  },
+  "devDependencies": {
+    "@hiero-ledger/solo": "0.83.0",
+    "@ledgerhq/wallet-framework-test-setup": "workspace:^",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "rimraf": "^5.0.5",
+    "typescript": "catalog:"
+  }
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/bridgeTarget.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/bridgeTarget.ts
@@ -1,0 +1,27 @@
+import type { AccountBridge, CurrencyBridge, TransactionCommon } from "@ledgerhq/types-live";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import type { ScenarioTransaction } from "@ledgerhq/coin-tester/main";
+import type { HederaAccount, TransactionStatus } from "@ledgerhq/coin-hedera/types";
+import type { CanonicalHederaTransaction } from "./canonicalTransaction";
+
+export type HederaBridgeSetup<T extends TransactionCommon> = (
+  tokens: TokenCurrency[],
+  maxAutomaticTokenAssociations?: number,
+) => Promise<{
+  currencyBridge: CurrencyBridge;
+  accountBridge: AccountBridge<T, HederaAccount, TransactionStatus>;
+  publicKey: string;
+  accountId: string;
+  close: () => void;
+}>;
+
+/**
+ * Everything a scenario needs to run against one specific bridge: how to set it up, how to turn
+ * a canonical transaction into that bridge's own transaction type, and how to read staking state
+ * back off an account synced through that bridge.
+ */
+export type HederaBridgeTarget<T extends TransactionCommon> = {
+  setup: HederaBridgeSetup<T>;
+  toTransaction: (canonical: CanonicalHederaTransaction) => ScenarioTransaction<T, HederaAccount>;
+  getStakingNodeId: (account: HederaAccount) => number | null;
+};

--- a/libs/coin-tester-modules/coin-tester-hedera/src/canonicalTransaction.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/canonicalTransaction.ts
@@ -1,0 +1,136 @@
+import BigNumber from "bignumber.js";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import type { ScenarioTransaction } from "@ledgerhq/coin-tester/main";
+import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/coin-hedera/constants";
+import type { Transaction, HederaAccount } from "@ledgerhq/coin-hedera/types";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
+
+export type CanonicalHederaMode = "send" | "tokenAssociate" | "delegate" | "undelegate";
+
+/**
+ * The fields a Hedera scenario transaction varies on, independent of which bridge builds and
+ * signs it. `toLegacyTransaction` and `toGenericHederaTransaction` map this to each bridge's own
+ * transaction type, so a scenario is written once and runs against both.
+ */
+export type CanonicalHederaTransaction = {
+  name: string;
+  mode: CanonicalHederaMode;
+  recipient: string;
+  amount?: BigNumber;
+  useAllAmount?: boolean;
+  subAccountId?: string;
+  memo?: string;
+  stakingNodeId?: number | null;
+  assetReference?: string;
+  assetOwner?: string;
+  token?: TokenCurrency;
+  expect?: (previous: HederaAccount, current: HederaAccount) => void;
+  xexpect?: (previous: HederaAccount, current: HederaAccount) => void;
+};
+
+const ZERO = new BigNumber(0);
+
+export function toLegacyTransaction(
+  c: CanonicalHederaTransaction,
+): ScenarioTransaction<Transaction, HederaAccount> {
+  const common = { name: c.name, expect: c.expect, xexpect: c.xexpect };
+
+  switch (c.mode) {
+    case "send":
+      return {
+        ...common,
+        family: "hedera",
+        mode: HEDERA_TRANSACTION_MODES.Send,
+        amount: c.amount ?? ZERO,
+        recipient: c.recipient,
+        useAllAmount: c.useAllAmount,
+        subAccountId: c.subAccountId,
+        memo: c.memo,
+      };
+    case "tokenAssociate": {
+      if (!c.assetReference || !c.assetOwner || !c.token) {
+        throw new Error(`canonical transaction "${c.name}" is missing token-associate fields`);
+      }
+      return {
+        ...common,
+        family: "hedera",
+        mode: HEDERA_TRANSACTION_MODES.TokenAssociate,
+        assetReference: c.assetReference,
+        assetOwner: c.assetOwner,
+        properties: { token: c.token },
+        amount: c.amount ?? ZERO,
+        recipient: c.recipient,
+      };
+    }
+    case "delegate":
+      return {
+        ...common,
+        family: "hedera",
+        mode: HEDERA_TRANSACTION_MODES.Delegate,
+        properties: { stakingNodeId: c.stakingNodeId ?? null },
+        amount: c.amount ?? ZERO,
+        recipient: c.recipient,
+      };
+    case "undelegate":
+      return {
+        ...common,
+        family: "hedera",
+        mode: HEDERA_TRANSACTION_MODES.Undelegate,
+        properties: { stakingNodeId: null },
+        amount: c.amount ?? ZERO,
+        recipient: c.recipient,
+      };
+  }
+}
+
+export function toGenericHederaTransaction(
+  c: CanonicalHederaTransaction,
+): ScenarioTransaction<GenericTransaction, HederaAccount> {
+  const common = { name: c.name, expect: c.expect, xexpect: c.xexpect };
+
+  switch (c.mode) {
+    case "send":
+      return {
+        ...common,
+        family: "hedera",
+        mode: "send",
+        amount: c.amount ?? ZERO,
+        recipient: c.recipient,
+        useAllAmount: c.useAllAmount,
+        subAccountId: c.subAccountId,
+        memoType: c.memo ? "text" : undefined,
+        memoValue: c.memo,
+      };
+    case "tokenAssociate": {
+      if (!c.assetReference || !c.assetOwner) {
+        throw new Error(`canonical transaction "${c.name}" is missing token-associate fields`);
+      }
+      return {
+        ...common,
+        family: "hedera",
+        mode: "token-associate",
+        assetReference: c.assetReference,
+        assetOwner: c.assetOwner,
+        amount: c.amount ?? ZERO,
+        recipient: c.recipient,
+      };
+    }
+    case "delegate":
+      return {
+        ...common,
+        family: "hedera",
+        mode: "delegate",
+        valId: c.stakingNodeId != null ? String(c.stakingNodeId) : undefined,
+        amount: c.amount ?? ZERO,
+        recipient: c.recipient,
+      };
+    case "undelegate":
+      return {
+        ...common,
+        family: "hedera",
+        mode: "undelegate",
+        amount: c.amount ?? ZERO,
+        recipient: c.recipient,
+      };
+  }
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/fixtures.test.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/fixtures.test.ts
@@ -1,0 +1,15 @@
+import { makeLocalErc20Token } from "./fixtures";
+
+describe("makeLocalErc20Token", () => {
+  it("lowercases the contract address", () => {
+    const token = makeLocalErc20Token("0xABCDEF0123456789abcdef0123456789ABCDEF01");
+
+    expect(token.contractAddress).toBe("0xabcdef0123456789abcdef0123456789abcdef01");
+  });
+
+  it("sets tokenType to erc20", () => {
+    const token = makeLocalErc20Token("0xabcdef0123456789abcdef0123456789abcdef01");
+
+    expect(token.tokenType).toBe("erc20");
+  });
+});

--- a/libs/coin-tester-modules/coin-tester-hedera/src/fixtures.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/fixtures.ts
@@ -1,0 +1,131 @@
+import BigNumber from "bignumber.js";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import { setCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
+import {
+  encodeAccountId,
+  decodeAccountId,
+} from "@ledgerhq/ledger-wallet-framework/account/accountId";
+import {
+  getDerivationScheme,
+  runDerivationScheme,
+} from "@ledgerhq/ledger-wallet-framework/derivation";
+import type { HederaAccount } from "@ledgerhq/coin-hedera/types";
+
+export const HEDERA = getCryptoCurrencyById("hedera");
+
+/** Local Solo's consensus endpoint; the port can differ between Solo versions. */
+export const LOCAL_CONSENSUS_NODES: Record<string, string> = { "127.0.0.1:35211": "0.0.3" };
+export const LOCAL_MIRROR_NODE_URL = "http://127.0.0.1:38081";
+/** Port Solo's mirror node listens on; derived so it tracks LOCAL_MIRROR_NODE_URL if it ever drifts. */
+export const LOCAL_MIRROR_NODE_PORT = new URL(LOCAL_MIRROR_NODE_URL).port;
+
+export const GENESIS_ACCOUNT_ID = "0.0.2";
+
+/** Canonical genesis operator key of a local Hedera network — a public constant, not a secret. */
+export const GENESIS_OPERATOR_KEY =
+  "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137";
+
+/**
+ * Fake hgraph URL served only by indexer.ts's MSW handler; coin-hedera calls hgraph unconditionally.
+ * A `.mock` domain that resolves nowhere — if a request ever escapes the MSW handler it fails
+ * instantly and locally instead of leaving the machine (unlike a localhost port, which the msw
+ * carve-out for the real mirror node would otherwise wave through).
+ */
+export const FAKE_HGRAPH_URL = "https://hedera-coin-tester.mock/hgraph";
+
+/** An existing Solo-funded account used only as the send recipient; its key is never needed. */
+export const RECIPIENT = "0.0.1002";
+
+export function makeHederaAccount(accountId: string, publicKey: string): HederaAccount {
+  const id = encodeAccountId({
+    type: "js",
+    version: "2",
+    currencyId: HEDERA.id,
+    xpubOrAddress: accountId,
+    derivationMode: "hederaBip44",
+  });
+  const { derivationMode } = decodeAccountId(id);
+  const scheme = getDerivationScheme({ derivationMode, currency: HEDERA });
+  const freshAddressPath = runDerivationScheme(scheme, HEDERA, {});
+
+  return {
+    type: "Account",
+    id,
+    seedIdentifier: publicKey,
+    derivationMode,
+    index: 0,
+    freshAddress: accountId,
+    freshAddressPath,
+    used: false,
+    balance: new BigNumber(0),
+    spendableBalance: new BigNumber(0),
+    creationDate: new Date(),
+    blockHeight: 0,
+    currency: HEDERA,
+    operationsCount: 0,
+    operations: [],
+    pendingOperations: [],
+    lastSyncDate: new Date(0),
+    balanceHistoryCache: {
+      HOUR: { latestDate: null, balances: [] },
+      DAY: { latestDate: null, balances: [] },
+      WEEK: { latestDate: null, balances: [] },
+    },
+    swapHistory: [],
+    subAccounts: [],
+  };
+}
+
+export const TOKEN_DECIMALS = 2;
+export const TOKEN_SYMBOL = "LLT";
+export const TOKEN_UNIT = 10 ** TOKEN_DECIMALS;
+
+export const ONE_HBAR_IN_TINYBAR = 100_000_000;
+
+/** Headroom above any scenario's token count — deliberately NOT the -1 "unlimited" sentinel. */
+export const MAX_AUTO_ASSOCIATIONS = 10;
+
+/** Stubbed HBAR/USD rate. Fee estimates derive from it, so no assertion may depend on its value. */
+export const HBAR_USD_RATE = 0.1;
+
+/** A `TokenCurrency` for a locally-minted token; `contractAddress` must be the mirror-node `token_id`. */
+export function makeLocalHtsToken(tokenId: string): TokenCurrency {
+  return {
+    type: "TokenCurrency",
+    id: `hedera/hts/${tokenId}`,
+    contractAddress: tokenId,
+    parentCurrencyId: HEDERA.id,
+    tokenType: "hts",
+    name: "Ledger Live Test Token",
+    ticker: TOKEN_SYMBOL,
+    units: [{ name: "Ledger Live Test Token", code: TOKEN_SYMBOL, magnitude: TOKEN_DECIMALS }],
+  };
+}
+
+/** A `TokenCurrency` for the locally-deployed ERC20 fixture; `contractAddress` must be the `0x`-prefixed EVM address. */
+export function makeLocalErc20Token(evmAddress: string): TokenCurrency {
+  const contractAddress = evmAddress.toLowerCase();
+  return {
+    type: "TokenCurrency",
+    id: `hedera/erc20/${contractAddress}`,
+    contractAddress,
+    parentCurrencyId: HEDERA.id,
+    tokenType: "erc20",
+    name: "Ledger Live Test Token",
+    ticker: TOKEN_SYMBOL,
+    units: [{ name: "Ledger Live Test Token", code: TOKEN_SYMBOL, magnitude: TOKEN_DECIMALS }],
+  };
+}
+
+export function installCryptoAssetsStore(tokens: TokenCurrency[]): void {
+  const byAddress = new Map(tokens.map(t => [t.contractAddress.toLowerCase(), t]));
+  const byId = new Map(tokens.map(t => [t.id, t]));
+
+  setCryptoAssetsStore({
+    findTokenById: async (id: string) => byId.get(id),
+    findTokenByAddressInCurrency: async (address: string, currencyId: string) =>
+      currencyId === HEDERA.id ? byAddress.get(address.toLowerCase()) : undefined,
+    getTokensSyncHash: async () => "",
+  });
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/fixtures/LedgerLiveTestToken.json
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/fixtures/LedgerLiveTestToken.json
@@ -1,0 +1,153 @@
+{
+  "name": "LedgerLiveTestToken",
+  "origin": "Own minimal ERC20 for coin-tester-hedera (not a mainnet snapshot: mainnet tokens carry\npausable/ownable/blacklist logic that can fire unpredictably on a local net).\n\nCompiled with solc-js 0.8.36 (npx --yes solc@0.8.36), via:\n  npx --yes solc@0.8.36 --optimize --bin --abi -o out LedgerLiveTestToken.sol\n\nRefresh by writing the source below to a .sol file and re-running the command above; do not\ncommit the .sol file itself (CI never compiles it, so it would silently drift from the bytecode).\n\nSource:\n// SPDX-License-Identifier: MIT\npragma solidity 0.8.36;\n\n/// @notice Minimal ERC20 for coin-tester-hedera's local Solo network. Deliberately bare —\n/// no pause/owner/blacklist hooks that could fire unpredictably against a bridge under test.\ncontract LedgerLiveTestToken {\n    string public name;\n    string public symbol;\n    uint8 public decimals;\n    uint256 public totalSupply;\n\n    mapping(address => uint256) public balanceOf;\n\n    event Transfer(address indexed from, address indexed to, uint256 value);\n\n    constructor(string memory _name, string memory _symbol, uint8 _decimals, uint256 _initialSupply) {\n        name = _name;\n        symbol = _symbol;\n        decimals = _decimals;\n        totalSupply = _initialSupply;\n        balanceOf[msg.sender] = _initialSupply;\n        emit Transfer(address(0), msg.sender, _initialSupply);\n    }\n\n    function transfer(address to, uint256 value) external returns (bool) {\n        require(balanceOf[msg.sender] >= value, \"ERC20: insufficient balance\");\n        balanceOf[msg.sender] -= value;\n        balanceOf[to] += value;\n        emit Transfer(msg.sender, to, value);\n        return true;\n    }\n}\n",
+  "bytecode": "0x608060405234801561000f575f5ffd5b506040516106f63803806106f683398101604081905261002e91610144565b5f6100398582610256565b5060016100468482610256565b506002805460ff191660ff84161790556003819055335f818152600460209081526040808320859055518481527fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef910160405180910390a350505050610314565b634e487b7160e01b5f52604160045260245ffd5b5f82601f8301126100ca575f5ffd5b81516001600160401b038111156100e3576100e36100a7565b604051601f8201601f19908116603f011681016001600160401b0381118282101715610111576101116100a7565b604052818152838201602001851015610128575f5ffd5b8160208501602083015e5f918101602001919091529392505050565b5f5f5f5f60808587031215610157575f5ffd5b84516001600160401b0381111561016c575f5ffd5b610178878288016100bb565b602087015190955090506001600160401b03811115610195575f5ffd5b6101a1878288016100bb565b935050604085015160ff811681146101b7575f5ffd5b6060959095015193969295505050565b600181811c908216806101db57607f821691505b6020821081036101f957634e487b7160e01b5f52602260045260245ffd5b50919050565b601f821115610251578282111561025157805f5260205f20601f840160051c602085101561022a57505f5b90810190601f840160051c035f5b8181101561024d575f83820155600101610238565b5050505b505050565b81516001600160401b0381111561026f5761026f6100a7565b6102838161027d84546101c7565b846101ff565b6020601f8211600181146102b5575f831561029e5750848201515b5f19600385901b1c1916600184901b17845561030d565b5f84815260208120601f198516915b828110156102e457878501518255602094850194600190920191016102c4565b508482101561030157868401515f19600387901b60f8161c191681555b505060018360011b0184555b5050505050565b6103d5806103215f395ff3fe608060405234801561000f575f5ffd5b5060043610610060575f3560e01c806306fdde031461006457806318160ddd14610082578063313ce5671461009957806370a08231146100b857806395d89b41146100d7578063a9059cbb146100df575b5f5ffd5b61006c610102565b6040516100799190610295565b60405180910390f35b61008b60035481565b604051908152602001610079565b6002546100a69060ff1681565b60405160ff9091168152602001610079565b61008b6100c63660046102e5565b60046020525f908152604090205481565b61006c61018d565b6100f26100ed366004610305565b61019a565b6040519015158152602001610079565b5f805461010e9061032d565b80601f016020809104026020016040519081016040528092919081815260200182805461013a9061032d565b80156101855780601f1061015c57610100808354040283529160200191610185565b820191905f5260205f20905b81548152906001019060200180831161016857829003601f168201915b505050505081565b6001805461010e9061032d565b335f908152600460205260408120548211156101fc5760405162461bcd60e51b815260206004820152601b60248201527f45524332303a20696e73756666696369656e742062616c616e63650000000000604482015260640160405180910390fd5b335f908152600460205260408120805484929061021a908490610379565b90915550506001600160a01b0383165f908152600460205260408120805484929061024690849061038c565b90915550506040518281526001600160a01b0384169033907fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef9060200160405180910390a35060015b92915050565b602081525f82518060208401528060208501604085015e5f604082850101526040601f19601f83011684010191505092915050565b80356001600160a01b03811681146102e0575f5ffd5b919050565b5f602082840312156102f5575f5ffd5b6102fe826102ca565b9392505050565b5f5f60408385031215610316575f5ffd5b61031f836102ca565b946020939093013593505050565b600181811c9082168061034157607f821691505b60208210810361035f57634e487b7160e01b5f52602260045260245ffd5b50919050565b634e487b7160e01b5f52601160045260245ffd5b8181038181111561028f5761028f610365565b8082018082111561028f5761028f61036556fea264697066735822122008864af55e40c14106954cd7e69a481e28774ccaabec3d7790264ea0a86b079a64736f6c63430008240033",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_symbol",
+          "type": "string"
+        },
+        {
+          "internalType": "uint8",
+          "name": "_decimals",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_initialSupply",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/genericHelpers.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/genericHelpers.ts
@@ -1,0 +1,123 @@
+import type { AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
+import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
+import hederaCoinConfig from "@ledgerhq/coin-hedera/config";
+import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
+import type { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
+import { getCoinFrameworkAccountBridge } from "@ledgerhq/live-common/bridge/generic-coin-framework/accountBridge";
+import { getCoinFrameworkCurrencyBridge } from "@ledgerhq/live-common/bridge/generic-coin-framework/currencyBridge";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
+import {
+  deserializeTransaction,
+  getHederaTransactionBodyBytes,
+  serializeSignature,
+} from "@ledgerhq/coin-hedera/logic/utils";
+import type { TransactionStatus, HederaAccount, HederaSigner } from "@ledgerhq/coin-hedera/types";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import { registerCoinModules } from "@ledgerhq/live-common/coin-modules/registry";
+import { coinModuleLoaders } from "@ledgerhq/live-common/coin-modules/loaders";
+import { toGenericHederaTransaction } from "./canonicalTransaction";
+import type { HederaBridgeTarget } from "./bridgeTarget";
+import { buildLocalHederaConfig } from "./helpers";
+import { HEDERA, installCryptoAssetsStore } from "./fixtures";
+import { buildHederaSigner } from "./signer";
+import { createFundedAccount } from "./genesis";
+import { initMswHandlers } from "./indexer";
+
+/** Every scenario account starts funded with this many HBAR from the genesis operator. */
+const INITIAL_BALANCE_HBAR = 100;
+
+registerCoinModules(coinModuleLoaders);
+
+export async function getGenericBridges(signer: HederaSigner): Promise<{
+  currencyBridge: CurrencyBridge;
+  accountBridge: AccountBridge<GenericTransaction, HederaAccount, TransactionStatus>;
+  getAddress: GetAddressFn;
+}> {
+  // The generic framework signs through the `families/hedera/signer.ts` shape — `getAddress(path)`
+  // plus `signTransaction(path, rawTxHex)` — while the tester's software signer speaks the raw
+  // device API. This adapter is `createSignerHedera` with the software key in place of a Transport.
+  const coinSigner = {
+    getAddress: async (path: string) => {
+      const publicKey = await signer.getPublicKey(path);
+      // Hedera has no on-device address computation; the public key doubles as the address.
+      return { path, address: publicKey, publicKey };
+    },
+    signTransaction: async (path: string, rawTxHex: string) => {
+      const tx = deserializeTransaction(rawTxHex);
+      const bodyBytes = getHederaTransactionBodyBytes(tx);
+      const signature = await signer.signTransaction(bodyBytes);
+      return serializeSignature(signature);
+    },
+  };
+  const signerContext: SignerContext<typeof coinSigner> = (_deviceId, fn) => fn(coinSigner);
+
+  // The legacy `createBridges` takes the coin config as an argument. The generic framework reads
+  // it back out of LiveConfig instead, through `families/hedera/coinModuleApi.ts`, so both stores
+  // have to be primed before a bridge is built.
+  const localConfig = buildLocalHederaConfig();
+  hederaCoinConfig.setCoinConfig(() => localConfig);
+  LiveConfig.setConfig({
+    config_currency_hedera: {
+      type: "object",
+      default: localConfig,
+    },
+  });
+
+  const getAddress: GetAddressFn = (deviceId, { path }) =>
+    signerContext(deviceId, s => s.getAddress(path));
+  const customSigner = { context: signerContext, getAddress };
+
+  const [currencyBridge, accountBridge] = await Promise.all([
+    getCoinFrameworkCurrencyBridge("hedera", "local", customSigner),
+    getCoinFrameworkAccountBridge("hedera", "local", customSigner),
+  ]);
+
+  return { currencyBridge, accountBridge, getAddress };
+}
+
+export async function setupGenericHederaScenario(
+  tokens: TokenCurrency[],
+  maxAutomaticTokenAssociations?: number,
+): Promise<{
+  currencyBridge: CurrencyBridge;
+  accountBridge: AccountBridge<GenericTransaction, HederaAccount, TransactionStatus>;
+  publicKey: string;
+  accountId: string;
+  close: () => void;
+}> {
+  installCryptoAssetsStore(tokens);
+
+  const signer = buildHederaSigner();
+  const { currencyBridge, accountBridge, getAddress } = await getGenericBridges(signer);
+
+  const { publicKey } = await getAddress("", {
+    path: "44/3030",
+    currency: HEDERA,
+    derivationMode: "hederaBip44",
+  });
+
+  const close = initMswHandlers();
+
+  const accountId = await createFundedAccount(
+    publicKey,
+    INITIAL_BALANCE_HBAR,
+    maxAutomaticTokenAssociations,
+  );
+
+  return { currencyBridge, accountBridge, publicKey, accountId, close };
+}
+
+/** Generic-framework staking positions carry `stakedNodeId` in `details`, a free-form map — read
+ * it back with a type guard instead of trusting the framework's `Record<string, unknown>`. A
+ * `stakedNodeId` of -1 is the mirror node's sentinel for "not delegated", matching how `hederaResources`
+ * reads on the legacy side. */
+export function getGenericStakingNodeId(account: HederaAccount): number | null {
+  const stakedNodeId = account.stakingPositions?.[0]?.details?.stakedNodeId;
+  return typeof stakedNodeId === "number" && stakedNodeId >= 0 ? stakedNodeId : null;
+}
+
+export const genericTarget: HederaBridgeTarget<GenericTransaction> = {
+  setup: setupGenericHederaScenario,
+  toTransaction: toGenericHederaTransaction,
+  getStakingNodeId: getGenericStakingNodeId,
+};

--- a/libs/coin-tester-modules/coin-tester-hedera/src/genesis.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/genesis.ts
@@ -1,0 +1,298 @@
+import {
+  AccountCreateTransaction,
+  AccountId,
+  Client,
+  ContractCreateFlow,
+  ContractExecuteTransaction,
+  ContractFunctionParameters,
+  ContractId,
+  Hbar,
+  PrivateKey,
+  PublicKey,
+  TokenAssociateTransaction,
+  TokenCreateTransaction,
+  TokenId,
+  TokenType,
+  TransactionId,
+  TransferTransaction,
+} from "@hashgraph/sdk";
+import {
+  GENESIS_ACCOUNT_ID,
+  GENESIS_OPERATOR_KEY,
+  LOCAL_CONSENSUS_NODES,
+  LOCAL_MIRROR_NODE_URL,
+  TOKEN_DECIMALS,
+  TOKEN_SYMBOL,
+} from "./fixtures";
+import { deploySolo } from "./solo";
+import erc20Artifact from "./fixtures/LedgerLiveTestToken.json";
+
+const MIRROR_NODE_POLL_TIMEOUT_MS = 30_000;
+const MIRROR_NODE_POLL_INTERVAL_MS = 1_000;
+
+let client: Client | undefined;
+
+/** Genesis-operator client, memoised alongside the deployment it belongs to. */
+export async function getGenesisClient(): Promise<Client> {
+  if (!client) {
+    await deploySolo();
+    const created = Client.forNetwork(LOCAL_CONSENSUS_NODES, { scheduleNetworkUpdate: false });
+    created.setOperator(GENESIS_ACCOUNT_ID, PrivateKey.fromStringED25519(GENESIS_OPERATOR_KEY));
+    client = created;
+  }
+  return client;
+}
+
+export function closeGenesisClient(): void {
+  client?.close();
+  client = undefined;
+}
+
+/** `T` is the caller's assertion about the mirror-node payload, as in `getFirstNodeId` below. */
+async function pollMirrorNode<T>(
+  path: string,
+  isReady: (body: T) => boolean,
+  describeFailure: string,
+  init?: RequestInit,
+): Promise<void> {
+  const deadline = Date.now() + MIRROR_NODE_POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const res = await fetch(`${LOCAL_MIRROR_NODE_URL}${path}`, init).catch(() => undefined);
+    if (res?.ok && isReady((await res.json()) as T)) return;
+    await new Promise(resolve => setTimeout(resolve, MIRROR_NODE_POLL_INTERVAL_MS));
+  }
+  throw new Error(`hedera genesis: ${describeFailure} within ${MIRROR_NODE_POLL_TIMEOUT_MS}ms`);
+}
+
+/**
+ * `evm_address` can be unset right after account creation; coin-hedera's `getAccountShape` throws
+ * hard on that. Returns the address so callers (e.g. the ERC20 scenario, which needs it to seed
+ * the account under test via a raw `transferErc20`) don't have to re-fetch it themselves.
+ */
+export async function waitForMirrorNodeEvmAddress(accountId: string): Promise<string> {
+  let evmAddress: string | undefined;
+  await pollMirrorNode<{ evm_address?: string }>(
+    `/api/v1/accounts/${accountId}`,
+    body => {
+      evmAddress = body?.evm_address;
+      return Boolean(evmAddress);
+    },
+    `mirror node never populated evm_address for ${accountId}`,
+  );
+  return evmAddress!;
+}
+
+/** Waits for a token balance to be indexed; the runner's retry loop wraps only `expect`, not this. */
+export async function waitForMirrorNodeTokenBalance(
+  accountId: string,
+  tokenId: string,
+  atLeast: number,
+): Promise<void> {
+  await pollMirrorNode<{ tokens?: { token_id: string; balance: number }[] }>(
+    `/api/v1/accounts/${accountId}/tokens`,
+    body => (body?.tokens ?? []).some(t => t.token_id === tokenId && t.balance >= atLeast),
+    `mirror node never reported a balance of ${atLeast} for token ${tokenId} on ${accountId}`,
+  );
+}
+
+/** The consensus node to stake to. Can't use the bridge's preload data: `sortValidators` reorders it. */
+export async function getFirstNodeId(): Promise<number> {
+  const res = await fetch(`${LOCAL_MIRROR_NODE_URL}/api/v1/network/nodes?limit=1&order=asc`);
+  if (!res.ok) {
+    throw new Error(`hedera genesis: mirror node /network/nodes returned ${res.status}`);
+  }
+  const nodeId = ((await res.json()) as { nodes?: { node_id: number }[] }).nodes?.[0]?.node_id;
+  if (typeof nodeId !== "number") {
+    throw new Error("hedera genesis: mirror node reported no consensus nodes to stake to");
+  }
+  return nodeId;
+}
+
+export async function createFundedAccount(
+  publicKey: string,
+  hbar: number,
+  maxAutomaticTokenAssociations?: number,
+): Promise<string> {
+  const genesis = await getGenesisClient();
+
+  const transaction = new AccountCreateTransaction()
+    .setKeyWithoutAlias(PublicKey.fromString(publicKey))
+    .setInitialBalance(new Hbar(hbar))
+    .setTransactionId(TransactionId.generate(GENESIS_ACCOUNT_ID));
+
+  if (maxAutomaticTokenAssociations && maxAutomaticTokenAssociations > 0) {
+    transaction.setMaxAutomaticTokenAssociations(maxAutomaticTokenAssociations);
+  }
+
+  const receipt = await transaction.execute(genesis).then(response => response.getReceipt(genesis));
+
+  const accountId = receipt.accountId?.toString();
+  if (!accountId) {
+    throw new Error("hedera genesis: AccountCreateTransaction receipt has no accountId");
+  }
+
+  await waitForMirrorNodeEvmAddress(accountId);
+  return accountId;
+}
+
+export async function createHtsToken({
+  decimals,
+  symbol,
+  initialSupply,
+}: {
+  decimals: number;
+  symbol: string;
+  initialSupply: number;
+}): Promise<string> {
+  const genesis = await getGenesisClient();
+  const operatorKey = genesis.operatorPublicKey;
+  if (!operatorKey) throw new Error("hedera genesis: client has no operator public key");
+
+  const receipt = await new TokenCreateTransaction()
+    .setTokenName("Ledger Live Test Token")
+    .setTokenSymbol(symbol)
+    .setTokenType(TokenType.FungibleCommon)
+    .setDecimals(decimals)
+    .setInitialSupply(initialSupply)
+    .setTreasuryAccountId(AccountId.fromString(GENESIS_ACCOUNT_ID))
+    .setAdminKey(operatorKey)
+    .setSupplyKey(operatorKey)
+    .setTransactionId(TransactionId.generate(GENESIS_ACCOUNT_ID))
+    .execute(genesis)
+    .then(response => response.getReceipt(genesis));
+
+  const tokenId = receipt.tokenId?.toString();
+  if (!tokenId) {
+    throw new Error("hedera genesis: TokenCreateTransaction receipt has no tokenId");
+  }
+  return tokenId;
+}
+
+/** Associates a *fixture* account with a token via its own key; the account under test associates through the bridge instead. */
+export async function associateToken(
+  accountId: string,
+  key: PrivateKey,
+  tokenId: string,
+): Promise<void> {
+  const genesis = await getGenesisClient();
+
+  const signed = await new TokenAssociateTransaction()
+    .setAccountId(AccountId.fromString(accountId))
+    .setTokenIds([TokenId.fromString(tokenId)])
+    .setTransactionId(TransactionId.generate(GENESIS_ACCOUNT_ID))
+    .freezeWith(genesis)
+    .sign(key);
+
+  await signed.execute(genesis).then(response => response.getReceipt(genesis));
+}
+
+/** Transfers fungible units from the treasury (0.0.2) to an already-associated account. */
+export async function transferToken(
+  tokenId: string,
+  toAccountId: string,
+  amount: number,
+): Promise<void> {
+  const genesis = await getGenesisClient();
+
+  await new TransferTransaction()
+    .addTokenTransfer(
+      TokenId.fromString(tokenId),
+      AccountId.fromString(GENESIS_ACCOUNT_ID),
+      -amount,
+    )
+    .addTokenTransfer(TokenId.fromString(tokenId), AccountId.fromString(toAccountId), amount)
+    .setTransactionId(TransactionId.generate(GENESIS_ACCOUNT_ID))
+    .execute(genesis)
+    .then(response => response.getReceipt(genesis));
+}
+
+// Deploy needs ~330-362k gas; 300,000 fails with INSUFFICIENT_GAS. Headroom is free here since
+// Solo's genesis account holds ~50B HBAR.
+const ERC20_DEPLOY_GAS = 1_000_000;
+const ERC20_CALL_GAS = 100_000;
+const ERC20_INITIAL_SUPPLY = 1_000_000;
+
+/** `keccak256("balanceOf(address)")[:4]` — the standard ERC20 selector, stable across compilers. */
+const BALANCE_OF_SELECTOR = "70a08231";
+
+function encodeBalanceOfCall(accountEvmAddress: string): string {
+  const address = accountEvmAddress.replace(/^0x/, "").toLowerCase();
+  return `0x${BALANCE_OF_SELECTOR}${address.padStart(64, "0")}`;
+}
+
+/** Deploys the fixture ERC20 (see `fixtures/LedgerLiveTestToken.json`), minting the whole supply to the genesis operator. */
+export async function deployErc20Token(): Promise<{ contractId: string; evmAddress: string }> {
+  const genesis = await getGenesisClient();
+
+  const constructorParameters = new ContractFunctionParameters()
+    .addString("Ledger Live Test Token")
+    .addString(TOKEN_SYMBOL)
+    .addUint8(TOKEN_DECIMALS)
+    .addUint256(ERC20_INITIAL_SUPPLY);
+
+  const receipt = await new ContractCreateFlow()
+    .setBytecode(erc20Artifact.bytecode)
+    .setGas(ERC20_DEPLOY_GAS)
+    .setConstructorParameters(constructorParameters)
+    .execute(genesis)
+    .then(response => response.getReceipt(genesis));
+
+  const contractId = receipt.contractId?.toString();
+  if (!contractId) {
+    throw new Error("hedera genesis: ContractCreateFlow receipt has no contractId");
+  }
+
+  let evmAddress: string | undefined;
+  await pollMirrorNode<{ evm_address?: string }>(
+    `/api/v1/contracts/${contractId}`,
+    body => {
+      evmAddress = body?.evm_address;
+      return Boolean(evmAddress);
+    },
+    `mirror node never populated evm_address for contract ${contractId}`,
+  );
+
+  return { contractId, evmAddress: evmAddress! };
+}
+
+/** Transfers ERC20 units from the genesis operator (the mint recipient) to `toEvmAddress`. */
+export async function transferErc20(
+  evmAddress: string,
+  toEvmAddress: string,
+  amount: number,
+): Promise<void> {
+  const genesis = await getGenesisClient();
+
+  await new ContractExecuteTransaction()
+    .setContractId(ContractId.fromEvmAddress(0, 0, evmAddress))
+    .setGas(ERC20_CALL_GAS)
+    .setFunction(
+      "transfer",
+      new ContractFunctionParameters().addAddress(toEvmAddress).addUint256(amount),
+    )
+    .setTransactionId(TransactionId.generate(GENESIS_ACCOUNT_ID))
+    .execute(genesis)
+    .then(response => response.getReceipt(genesis));
+}
+
+/** Polls `balanceOf` via the same mirror-node `contracts/call` endpoint the hgraph fake reads from. */
+export async function waitForErc20Balance(
+  evmAddress: string,
+  accountEvmAddress: string,
+  expected: number,
+): Promise<void> {
+  await pollMirrorNode<{ result?: string }>(
+    "/api/v1/contracts/call",
+    body => typeof body?.result === "string" && BigInt(body.result) >= BigInt(expected),
+    `mirror node never reported a balance of ${expected} for ${accountEvmAddress} on contract ${evmAddress}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        block: "latest",
+        to: evmAddress,
+        data: encodeBalanceOfCall(accountEvmAddress),
+      }),
+    },
+  );
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/helpers.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/helpers.ts
@@ -1,0 +1,122 @@
+import type { AccountBridge, CurrencyBridge, TokenAccount } from "@ledgerhq/types-live";
+import type { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
+import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
+import { createBridges } from "@ledgerhq/coin-hedera/bridge/index";
+import type { HederaCoinConfig } from "@ledgerhq/coin-hedera/config";
+import hederaResolver from "@ledgerhq/coin-hedera/signer/index";
+import type {
+  Transaction,
+  TransactionStatus,
+  HederaAccount,
+  HederaSigner,
+} from "@ledgerhq/coin-hedera/types";
+import type { Scenario } from "@ledgerhq/coin-tester/main";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import { registerCoinModules } from "@ledgerhq/live-common/coin-modules/registry";
+import { coinModuleLoaders } from "@ledgerhq/live-common/coin-modules/loaders";
+import { toLegacyTransaction } from "./canonicalTransaction";
+import type { HederaBridgeTarget } from "./bridgeTarget";
+import {
+  FAKE_HGRAPH_URL,
+  HEDERA,
+  LOCAL_CONSENSUS_NODES,
+  LOCAL_MIRROR_NODE_URL,
+  installCryptoAssetsStore,
+} from "./fixtures";
+import { buildHederaSigner } from "./signer";
+import { createFundedAccount } from "./genesis";
+import { initMswHandlers } from "./indexer";
+
+/** Every scenario account starts funded with this many HBAR from the genesis operator. */
+const INITIAL_BALANCE_HBAR = 100;
+
+type ScenarioSetupResult = Awaited<ReturnType<Scenario<Transaction, HederaAccount>["setup"]>>;
+
+/** Absorbs the mirror node's lag behind consensus — for `expect` only, nothing earlier. */
+export const SCENARIO_RETRY_POLICY: Pick<ScenarioSetupResult, "retryInterval" | "retryLimit"> = {
+  retryInterval: 2000,
+  retryLimit: 20,
+};
+
+/** Finds the sub-account for a given token id, however the caller has that token at hand. */
+export function findTokenSubAccount(
+  account: HederaAccount,
+  tokenId: string,
+): TokenAccount | undefined {
+  return account.subAccounts?.find(sa => sa.type === "TokenAccount" && sa.token.id === tokenId) as
+    | TokenAccount
+    | undefined;
+}
+
+registerCoinModules(coinModuleLoaders);
+
+// `networkType: "testnet"` is a label only — `consensusNodes` and `apiUrls` override the actual endpoints.
+export function buildLocalHederaConfig(): HederaCoinConfig {
+  return {
+    status: { type: "active" },
+    useNetworkTimestamp: false,
+    networkType: "testnet",
+    consensusNodes: LOCAL_CONSENSUS_NODES,
+    apiUrls: {
+      mirrorNode: LOCAL_MIRROR_NODE_URL,
+      hgraph: FAKE_HGRAPH_URL,
+    },
+  };
+}
+
+export async function getBridges(signer: HederaSigner): Promise<{
+  currencyBridge: CurrencyBridge;
+  accountBridge: AccountBridge<Transaction, HederaAccount, TransactionStatus>;
+  getAddress: GetAddressFn;
+}> {
+  const signerContext: SignerContext<HederaSigner> = (_deviceId, fn) => fn(signer);
+  const localConfig = buildLocalHederaConfig();
+
+  const { currencyBridge, accountBridge } = createBridges(signerContext, () => localConfig);
+  const getAddress = hederaResolver(signerContext);
+
+  return { currencyBridge, accountBridge, getAddress };
+}
+
+export async function setupHederaScenario(
+  tokens: TokenCurrency[],
+  maxAutomaticTokenAssociations?: number,
+): Promise<{
+  currencyBridge: CurrencyBridge;
+  accountBridge: AccountBridge<Transaction, HederaAccount, TransactionStatus>;
+  publicKey: string;
+  accountId: string;
+  close: () => void;
+}> {
+  installCryptoAssetsStore(tokens);
+
+  const signer = buildHederaSigner();
+  const { currencyBridge, accountBridge, getAddress } = await getBridges(signer);
+
+  const { publicKey } = await getAddress("", {
+    path: "44/3030",
+    currency: HEDERA,
+    derivationMode: "hederaBip44",
+  });
+
+  const close = initMswHandlers();
+
+  const accountId = await createFundedAccount(
+    publicKey,
+    INITIAL_BALANCE_HBAR,
+    maxAutomaticTokenAssociations,
+  );
+
+  return { currencyBridge, accountBridge, publicKey, accountId, close };
+}
+
+/** Legacy delegation state lives on `hederaResources`, not `stakingPositions`. */
+export function getLegacyStakingNodeId(account: HederaAccount): number | null {
+  return account.hederaResources?.delegation?.nodeId ?? null;
+}
+
+export const legacyTarget: HederaBridgeTarget<Transaction> = {
+  setup: setupHederaScenario,
+  toTransaction: toLegacyTransaction,
+  getStakingNodeId: getLegacyStakingNodeId,
+};

--- a/libs/coin-tester-modules/coin-tester-hedera/src/hgraphFake.test.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/hgraphFake.test.ts
@@ -1,0 +1,429 @@
+import {
+  encodeAbiParameters,
+  encodeEventTopics,
+  erc20Abi,
+  getAddress,
+  zeroAddress,
+  type Address,
+} from "viem";
+import {
+  getErcTokenAccountRows,
+  getErcTokenTransferRows,
+  getLatestEthereumTransactionTimestamp,
+  refresh,
+  registerErc20Token,
+  resetErc20Tokens,
+  type FakeErcTokenTransfer,
+} from "./hgraphFake";
+
+const TOKEN_CONTRACT_ID = "0.0.5005";
+const TOKEN_EVM = "0x1111111111111111111111111111111111111111";
+
+/** Mirrors accountNumToLongZeroEvmAddress in hgraphFake.ts — a plain test fixture builder, not a
+ * reimplementation of the decoder under test (that stays exercised only via the module's exports). */
+function longZero(num: number): Address {
+  return `0x${"0".repeat(24)}${num.toString(16).padStart(16, "0")}` as Address;
+}
+
+const ACCOUNT_NUM = 1002;
+const ACCOUNT_EVM = longZero(ACCOUNT_NUM);
+const OTHER_ACCOUNT_NUM = 2;
+const OTHER_ACCOUNT_EVM = longZero(OTHER_ACCOUNT_NUM);
+
+function transferLog(from: Address, to: Address, value: bigint) {
+  return {
+    address: TOKEN_EVM,
+    topics: encodeEventTopics({ abi: erc20Abi, eventName: "Transfer", args: { from, to } }),
+    data: encodeAbiParameters([{ type: "uint256" }], [value]),
+  };
+}
+
+function contractCallTx({
+  payerNum,
+  consensusTimestamp,
+  hash,
+}: {
+  payerNum: number;
+  consensusTimestamp: string;
+  hash: string;
+}) {
+  return {
+    transaction_id: `0.0.${payerNum}-1700000000-000000000`,
+    transaction_hash: hash,
+    consensus_timestamp: consensusTimestamp,
+    parent_consensus_timestamp: null,
+    entity_id: TOKEN_CONTRACT_ID,
+    name: "CONTRACTCALL",
+  };
+}
+
+/** Routes the fake's fetches to canned mirror-node responses, keyed loosely by URL/method so each
+ * test only has to describe the handful of endpoints it actually cares about. */
+function mockMirrorNode(routes: {
+  transactions?: ReturnType<typeof contractCallTx>[];
+  logsByTimestamp?: Record<string, ReturnType<typeof transferLog>[]>;
+  contractResults?: { timestamp: string }[];
+  contractCallResult?: string;
+}): jest.Mock {
+  const fetchMock = jest.fn(async (url: string) => {
+    if (url.includes("/api/v1/transactions?")) {
+      return {
+        ok: true,
+        json: async () => ({ transactions: routes.transactions ?? [], links: { next: null } }),
+      };
+    }
+    if (url.includes("/results/logs")) {
+      const timestamp = new URL(url).searchParams.get("timestamp")?.replace("eq:", "");
+      return {
+        ok: true,
+        json: async () => ({ logs: routes.logsByTimestamp?.[timestamp ?? ""] ?? [] }),
+      };
+    }
+    if (url.includes("/api/v1/contracts/results?")) {
+      return { ok: true, json: async () => ({ results: routes.contractResults ?? [] }) };
+    }
+    if (url.includes("/api/v1/contracts/call")) {
+      return {
+        ok: true,
+        json: async () => ({
+          result:
+            routes.contractCallResult ??
+            "0x00000000000000000000000000000000000000000000000000000000002710",
+        }),
+      };
+    }
+    throw new Error(`unmocked mirror-node request: ${url}`);
+  });
+  jest.spyOn(global, "fetch").mockImplementation(fetchMock as unknown as typeof fetch);
+  return fetchMock;
+}
+
+describe("hgraphFake", () => {
+  beforeEach(() => {
+    resetErc20Tokens();
+    registerErc20Token(TOKEN_CONTRACT_ID, TOKEN_EVM);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe("erc_token_transfer pagination", () => {
+    it("terminates at limit:1 instead of hanging, faithfully reproducing the _gt/desc client bug", async () => {
+      const timestamps = ["1753600001.000000000", "1753600002.000000000", "1753600003.000000000"];
+      const transactions = timestamps.map((ts, i) =>
+        contractCallTx({ payerNum: OTHER_ACCOUNT_NUM, consensusTimestamp: ts, hash: `hash${i}` }),
+      );
+      const logsByTimestamp = Object.fromEntries(
+        timestamps.map(ts => [ts, [transferLog(OTHER_ACCOUNT_EVM, ACCOUNT_EVM, 100n)]]),
+      );
+      mockMirrorNode({ transactions, logsByTimestamp });
+
+      await refresh();
+
+      // Drives the same loop coin-hedera's getERC20Transfers runs: cursor = null, then cursor =
+      // last row of the previous page, until a page comes back empty.
+      let cursor: string | null = null;
+      const cursorsSeen: (string | null)[] = [cursor];
+      const collected: FakeErcTokenTransfer[] = [];
+      let iterations = 0;
+
+      while (iterations < 10) {
+        iterations += 1;
+        const page = getErcTokenTransferRows({
+          accountId: String(ACCOUNT_NUM),
+          tokenEvmAddresses: [TOKEN_EVM],
+          cursor,
+          limit: 1,
+        });
+        if (page.length === 0) break;
+        collected.push(...page);
+        cursor = page[page.length - 1].consensus_timestamp;
+        cursorsSeen.push(cursor);
+      }
+
+      expect(iterations).toBeLessThan(10);
+      expect(cursorsSeen).toEqual([null, "1753600003000000000"]);
+      // Only the single newest transfer ever surfaces: the `_gt` direction is correct for asc but
+      // wrong for the client's actual desc order — a real coin-hedera bug, reproduced faithfully.
+      expect(collected).toHaveLength(1);
+      expect(collected[0].consensus_timestamp).toBe(cursorsSeen[1]);
+    });
+
+    it("throws a named error instead of hanging if queried past the page guard", async () => {
+      mockMirrorNode({ transactions: [] });
+      await refresh();
+
+      for (let i = 0; i < 50; i++) {
+        getErcTokenTransferRows({
+          accountId: String(ACCOUNT_NUM),
+          tokenEvmAddresses: [TOKEN_EVM],
+          cursor: null,
+          limit: 1,
+        });
+      }
+
+      expect(() =>
+        getErcTokenTransferRows({
+          accountId: String(ACCOUNT_NUM),
+          tokenEvmAddresses: [TOKEN_EVM],
+          cursor: null,
+          limit: 1,
+        }),
+      ).toThrow(/hgraphFake.*erc_token_transfer.*50 pages/);
+    });
+
+    it("throws if queried before refresh() ever populated a snapshot", () => {
+      expect(() =>
+        getErcTokenTransferRows({
+          accountId: String(ACCOUNT_NUM),
+          tokenEvmAddresses: [TOKEN_EVM],
+          cursor: null,
+          limit: 10,
+        }),
+      ).toThrow(/hgraphFake.*erc_token_transfer queried before refresh/);
+    });
+  });
+
+  describe("long-zero address decoding", () => {
+    it("decodes both sides of a transfer between two long-zero accounts", async () => {
+      const ts = "1753600010.000000000";
+      const tx = contractCallTx({ payerNum: OTHER_ACCOUNT_NUM, consensusTimestamp: ts, hash: "h" });
+      mockMirrorNode({
+        transactions: [tx],
+        logsByTimestamp: { [ts]: [transferLog(OTHER_ACCOUNT_EVM, ACCOUNT_EVM, 250n)] },
+      });
+
+      await refresh();
+      const rows = getErcTokenTransferRows({
+        accountId: String(ACCOUNT_NUM),
+        tokenEvmAddresses: [TOKEN_EVM],
+        cursor: null,
+        limit: 10,
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].sender_account_id).toBe(OTHER_ACCOUNT_NUM);
+      expect(rows[0].receiver_account_id).toBe(ACCOUNT_NUM);
+      expect(rows[0].sender_evm_address).toBe(OTHER_ACCOUNT_EVM);
+      expect(rows[0].receiver_evm_address).toBe(ACCOUNT_EVM);
+      expect(rows[0].transfer_type).toBe("transfer");
+      expect(rows[0].amount).toBe(250);
+      // transaction_hash on the fake row is the anchor transaction's transaction_id, not its
+      // mirror-node transaction_hash field (base64 SHA-384, which getContractCallResult can't resolve).
+      expect(rows[0].transaction_hash).toBe(tx.transaction_id);
+      expect(rows[0].transaction_hash).not.toBe(tx.transaction_hash);
+    });
+
+    it("leaves *_account_id null for a non-long-zero (ECDSA-alias) address", async () => {
+      const ts = "1753600011.000000000";
+      const aliasEvm = getAddress(`0x${"ab".repeat(20)}`); // not long-zero
+      mockMirrorNode({
+        transactions: [
+          contractCallTx({ payerNum: OTHER_ACCOUNT_NUM, consensusTimestamp: ts, hash: "h" }),
+        ],
+        logsByTimestamp: { [ts]: [transferLog(aliasEvm, ACCOUNT_EVM, 42n)] },
+      });
+
+      await refresh();
+      const rows = getErcTokenTransferRows({
+        accountId: String(ACCOUNT_NUM),
+        tokenEvmAddresses: [TOKEN_EVM],
+        cursor: null,
+        limit: 10,
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].sender_account_id).toBeNull();
+      expect(rows[0].sender_evm_address).toBe(aliasEvm.toLowerCase());
+      expect(rows[0].receiver_account_id).toBe(ACCOUNT_NUM);
+    });
+  });
+
+  describe("zero address", () => {
+    it("maps a from-zero Transfer to a mint with a null sender", async () => {
+      const ts = "1753600020.000000000";
+      mockMirrorNode({
+        transactions: [
+          contractCallTx({ payerNum: OTHER_ACCOUNT_NUM, consensusTimestamp: ts, hash: "h" }),
+        ],
+        logsByTimestamp: { [ts]: [transferLog(zeroAddress, ACCOUNT_EVM, 1_000_000n)] },
+      });
+
+      await refresh();
+      const rows = getErcTokenTransferRows({
+        accountId: String(ACCOUNT_NUM),
+        tokenEvmAddresses: [TOKEN_EVM],
+        cursor: null,
+        limit: 10,
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].transfer_type).toBe("mint");
+      expect(rows[0].sender_account_id).toBeNull();
+      expect(rows[0].sender_evm_address).toBeNull();
+      expect(rows[0].receiver_account_id).toBe(ACCOUNT_NUM);
+    });
+
+    it("maps a to-zero Transfer to a burn with a null receiver", async () => {
+      const ts = "1753600030.000000000";
+      mockMirrorNode({
+        transactions: [
+          contractCallTx({ payerNum: ACCOUNT_NUM, consensusTimestamp: ts, hash: "h" }),
+        ],
+        logsByTimestamp: { [ts]: [transferLog(ACCOUNT_EVM, zeroAddress, 500n)] },
+      });
+
+      await refresh();
+      const rows = getErcTokenTransferRows({
+        accountId: String(ACCOUNT_NUM),
+        tokenEvmAddresses: [TOKEN_EVM],
+        cursor: null,
+        limit: 10,
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].transfer_type).toBe("burn");
+      expect(rows[0].receiver_account_id).toBeNull();
+      expect(rows[0].receiver_evm_address).toBeNull();
+      expect(rows[0].sender_account_id).toBe(ACCOUNT_NUM);
+    });
+  });
+
+  describe("ethereum_transaction floor / isERC20Delayed invariant", () => {
+    it("floors to wall clock when no contract result exists yet (pre-contract scenarios)", async () => {
+      jest.useFakeTimers().setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      mockMirrorNode({ contractResults: [] });
+
+      const { consensus_timestamp } = await getLatestEthereumTransactionTimestamp();
+
+      expect(BigInt(consensus_timestamp)).toBe(BigInt(Date.now()) * 1_000_000n);
+    });
+
+    it("floors to wall clock (not an older contract result), keeping the isERC20Delayed invariant intact", async () => {
+      jest.useFakeTimers().setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      // A contract result from well before "now" must not make the reported timestamp regress
+      // below wall clock, or isERC20Delayed could silently drop a just-broadcast transaction.
+      mockMirrorNode({ contractResults: [{ timestamp: "1700000000.000000000" }] });
+
+      const { consensus_timestamp } = await getLatestEthereumTransactionTimestamp();
+
+      expect(BigInt(consensus_timestamp)).toBe(BigInt(Date.now()) * 1_000_000n);
+    });
+
+    it("takes the latest contract result when it is newer than wall clock", async () => {
+      jest.useFakeTimers().setSystemTime(new Date("2020-01-01T00:00:00.000Z"));
+      mockMirrorNode({ contractResults: [{ timestamp: "1753600099.000000007" }] });
+
+      const { consensus_timestamp } = await getLatestEthereumTransactionTimestamp();
+
+      expect(consensus_timestamp).toBe("1753600099000000007");
+    });
+  });
+
+  describe("refresh() failure handling", () => {
+    it("still throws the never-initialised guard when refresh() has never succeeded", async () => {
+      jest.spyOn(global, "fetch").mockRejectedValue(new Error("connection reset"));
+      const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      await expect(refresh()).resolves.toBeUndefined(); // swallowed, must not throw
+
+      expect(() =>
+        getErcTokenTransferRows({
+          accountId: String(ACCOUNT_NUM),
+          tokenEvmAddresses: [TOKEN_EVM],
+          cursor: null,
+          limit: 10,
+        }),
+      ).toThrow(/hgraphFake.*erc_token_transfer queried before refresh/);
+      expect(consoleError).toHaveBeenCalled();
+    });
+
+    it("retains the previous snapshot and does not throw when a later refresh() fails transiently", async () => {
+      const ts = "1753600040.000000000";
+      mockMirrorNode({
+        transactions: [
+          contractCallTx({ payerNum: OTHER_ACCOUNT_NUM, consensusTimestamp: ts, hash: "h" }),
+        ],
+        logsByTimestamp: { [ts]: [transferLog(OTHER_ACCOUNT_EVM, ACCOUNT_EVM, 777n)] },
+      });
+      await refresh();
+
+      const before = getErcTokenTransferRows({
+        accountId: String(ACCOUNT_NUM),
+        tokenEvmAddresses: [TOKEN_EVM],
+        cursor: null,
+        limit: 10,
+      });
+      expect(before).toHaveLength(1);
+      expect(before[0].amount).toBe(777);
+
+      jest.spyOn(global, "fetch").mockRejectedValue(new Error("503 from mirror node"));
+      const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      await expect(refresh()).resolves.toBeUndefined();
+      expect(consoleError).toHaveBeenCalled();
+
+      const after = getErcTokenTransferRows({
+        accountId: String(ACCOUNT_NUM),
+        tokenEvmAddresses: [TOKEN_EVM],
+        cursor: null,
+        limit: 10,
+      });
+      expect(after).toEqual(before);
+    });
+  });
+
+  describe("erc_token_account (relation semantics)", () => {
+    const ZERO_BALANCE_RESULT = `0x${"0".repeat(64)}`;
+
+    it("returns one row per registered token with a nonzero balance, reading the same contracts/call endpoint waitForErc20Balance polls", async () => {
+      const fetchMock = mockMirrorNode({});
+      await refresh();
+
+      const rows = await getErcTokenAccountRows({ accountId: String(ACCOUNT_NUM) });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].token_evm_address).toBe(TOKEN_EVM);
+      expect(rows[0].balance).toBe(10_000);
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/contracts/call"),
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("omits a token the account never interacted with — zero balance, no transfer history", async () => {
+      mockMirrorNode({ transactions: [], contractCallResult: ZERO_BALANCE_RESULT });
+      await refresh();
+
+      const rows = await getErcTokenAccountRows({ accountId: String(ACCOUNT_NUM) });
+
+      expect(rows).toEqual([]);
+    });
+
+    it("keeps a zero-balance token with transfer history while still omitting a zero-balance, history-less sibling", async () => {
+      const OTHER_TOKEN_CONTRACT_ID = "0.0.5006";
+      const OTHER_TOKEN_EVM = "0x2222222222222222222222222222222222222222";
+      registerErc20Token(OTHER_TOKEN_CONTRACT_ID, OTHER_TOKEN_EVM);
+
+      const ts = "1753600050.000000000";
+      const tx = contractCallTx({ payerNum: OTHER_ACCOUNT_NUM, consensusTimestamp: ts, hash: "h" });
+      mockMirrorNode({
+        transactions: [tx],
+        logsByTimestamp: { [ts]: [transferLog(OTHER_ACCOUNT_EVM, ACCOUNT_EVM, 100n)] },
+        contractCallResult: ZERO_BALANCE_RESULT,
+      });
+      await refresh();
+
+      const rows = await getErcTokenAccountRows({ accountId: String(ACCOUNT_NUM) });
+
+      // TOKEN_EVM has a transfer in the snapshot; OTHER_TOKEN_EVM never appears in one, so only
+      // TOKEN_EVM's zero-balance row survives — the sibling proves the filter is keyed on history,
+      // not merely present in this test's logs.
+      expect(rows).toHaveLength(1);
+      expect(rows[0].token_evm_address).toBe(TOKEN_EVM);
+      expect(rows[0].balance).toBe(0);
+    });
+  });
+});

--- a/libs/coin-tester-modules/coin-tester-hedera/src/hgraphFake.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/hgraphFake.ts
@@ -1,0 +1,389 @@
+// Translates real Solo mirror-node responses into the hgraph GraphQL response shapes coin-hedera
+// consumes (@ledgerhq/coin-hedera/types/hgraph). msw wiring lives in indexer.ts.
+import { decodeEventLog, encodeFunctionData, erc20Abi, zeroAddress, type Address } from "viem";
+import { LOCAL_MIRROR_NODE_URL } from "./fixtures";
+
+interface RegisteredToken {
+  contractId: string;
+  evmAddress: string;
+}
+
+const tokensByEvmAddress = new Map<string, RegisteredToken>();
+
+/** Marks the fake's own programming-error guards (missing `refresh()`, pagination runaway) as
+ * distinct from a genuine mirror-node I/O failure, so indexer.ts can rethrow instead of
+ * swallowing them into a well-formed empty response. */
+export class HgraphFakeGuardError extends Error {}
+
+/** Records a deployed ERC20 so the fake can answer hgraph queries about it. Keyed by
+ * `evmAddress.toLowerCase()`. */
+export function registerErc20Token(contractId: string, evmAddress: string): void {
+  tokensByEvmAddress.set(evmAddress.toLowerCase(), {
+    contractId,
+    evmAddress: evmAddress.toLowerCase(),
+  });
+}
+
+/** Clears the registry and any transfer snapshot. Not wired into `initMswHandlers` since
+ * `setupHederaScenario` handles registration itself; call from scenario teardown instead. */
+export function resetErc20Tokens(): void {
+  tokensByEvmAddress.clear();
+  transferSnapshot = null;
+  transferPageCount = 0;
+}
+
+// Mirrors coin-hedera's ERC20TokenAccount/ERC20TokenTransfer, except `consensus_timestamp` is a
+// digit string here even though coin-hedera types it `number`: `new BigNumber(digitString)`
+// round-trips exactly, where a JS `number` would lose precision.
+export interface FakeErcTokenAccount {
+  token_id: number;
+  token_evm_address: string;
+  balance: number;
+  balance_timestamp: number;
+  created_timestamp: number;
+}
+
+export type FakeTransferType = "mint" | "burn" | "transfer";
+
+export interface FakeErcTokenTransfer {
+  token_id: number;
+  token_evm_address: string;
+  sender_evm_address: string | null;
+  sender_account_id: number | null;
+  receiver_evm_address: string | null;
+  receiver_account_id: number | null;
+  payer_account_id: number;
+  amount: number;
+  transfer_type: FakeTransferType;
+  consensus_timestamp: string;
+  transaction_hash: string;
+}
+
+// ---- Shared helpers ------------------------------------------------------------------------------
+
+function entityNum(entityId: string): number {
+  return Number(entityId.split(".").pop());
+}
+
+/** Every account here is created via `setKeyWithoutAlias` (src/genesis.ts), so its EVM address is a
+ * "long-zero" address: 4 bytes shard + 8 bytes realm + 8 bytes num, shard/realm always zero for us. */
+const LONG_ZERO_PATTERN = /^0x0{24}([0-9a-f]{16})$/i;
+
+/** Decodes a long-zero EVM address to its account num arithmetically — no lookups, no cache.
+ * Returns `null` for a non-long-zero (ECDSA-alias) address: hgraph would leave `*_account_id`
+ * unindexed for such a party, and the consumer falls back to the EVM address. */
+function longZeroToAccountNum(evmAddress: string): number | null {
+  const match = evmAddress.match(LONG_ZERO_PATTERN);
+  return match ? Number(BigInt(`0x${match[1]}`)) : null;
+}
+
+function accountNumToLongZeroEvmAddress(accountNum: string | number): Address {
+  return `0x${"0".repeat(24)}${BigInt(accountNum).toString(16).padStart(16, "0")}` as Address;
+}
+
+/** `"1753600000.000000005"` -> `"1753600000000000005"` (hgraph.ts strips the dot the same way). */
+function toNanosDigitString(secondsDotNanos: string): string {
+  const [seconds, nanos = "0"] = secondsDotNanos.split(".");
+  return `${seconds}${nanos.padEnd(9, "0")}`;
+}
+
+function toNanosBigInt(secondsDotNanos: string): bigint {
+  return BigInt(toNanosDigitString(secondsDotNanos));
+}
+
+async function fetchMirrorNode<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${LOCAL_MIRROR_NODE_URL}${path}`, init);
+  if (!res.ok) {
+    throw new Error(`hgraphFake: ${init?.method ?? "GET"} ${path} returned ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+// Balance itself is answered live, one /contracts/call per registered token — same endpoint/shape
+// as waitForErc20Balance in genesis.ts. A zero-balance row additionally needs transferSnapshot
+// (see hasTransferHistory below), so a query before the first refresh() treats every zero-balance
+// token as history-less rather than throwing, degrading toward the caller's "no row" case.
+async function fetchBalance(token: RegisteredToken, accountId: string): Promise<bigint> {
+  const data = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: "balanceOf",
+    args: [accountNumToLongZeroEvmAddress(accountId)],
+  });
+
+  const body = await fetchMirrorNode<{ result?: string }>("/api/v1/contracts/call", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ block: "latest", to: token.evmAddress, data }),
+  });
+
+  if (typeof body.result !== "string") {
+    throw new Error(`hgraphFake: contracts/call for ${token.evmAddress} returned no result`);
+  }
+  return BigInt(body.result);
+}
+
+/** The real `erc_token_account` relation only ever carries a row once the account has interacted
+ * with the token: a zero-balance token the account never touched has no row to index in the
+ * first place. `transferSnapshot` is read here, not captured by reference, since it is
+ * reassigned by `refresh()` (declared as `let` further down this module). */
+function hasTransferHistory(accountNum: number, evmAddress: string): boolean {
+  const lowerEvmAddress = evmAddress.toLowerCase();
+  return (transferSnapshot ?? []).some(
+    row =>
+      row.token_evm_address.toLowerCase() === lowerEvmAddress &&
+      (row.sender_account_id === accountNum || row.receiver_account_id === accountNum),
+  );
+}
+
+/** Handler-facing entry point for the `erc_token_account` query. `accountId` is the numeric
+ * account num, matching what the real client sends. `token_id` is unused by coin-hedera on this
+ * path; filled with the real contract num for fidelity only. */
+export async function getErcTokenAccountRows({
+  accountId,
+}: {
+  accountId: string;
+}): Promise<FakeErcTokenAccount[]> {
+  const now = Date.now();
+  const accountNum = Number(accountId);
+  const rows = await Promise.all(
+    [...tokensByEvmAddress.values()].map(async token => {
+      const balance = await fetchBalance(token, accountId);
+      return {
+        token_id: entityNum(token.contractId),
+        token_evm_address: token.evmAddress,
+        // A future decimals bump could lose precision here; safe at this fixture's scale.
+        balance: Number(balance),
+        balance_timestamp: now,
+        created_timestamp: now,
+      };
+    }),
+  );
+  return rows.filter(
+    row => row.balance !== 0 || hasTransferHistory(accountNum, row.token_evm_address),
+  );
+}
+
+// erc_token_transfer reads from a frozen snapshot taken in refresh(), so cursor slicing (pagination
+// is stateful) stays safe against the underlying array growing mid-walk. Anchored on transactions,
+// not logs: a CONTRACTCALL transaction carries payer, consensus_timestamp and transaction_hash up
+// front, which logs don't. Every refresh() fully re-scans rather than tracking a cursor — volume
+// here is only double digits, and a forgotten-reset cursor fails worse (silent zero/cross-
+// contamination) than a full re-scan ever does.
+
+interface MirrorTransactionsPage {
+  transactions: {
+    transaction_id: string;
+    transaction_hash: string;
+    consensus_timestamp: string;
+    parent_consensus_timestamp: string | null;
+    entity_id: string | null;
+    name: string;
+  }[];
+  links?: { next: string | null };
+}
+
+interface MirrorContractLog {
+  address: string;
+  data: string;
+  topics: string[];
+}
+
+interface MirrorContractLogsPage {
+  logs: MirrorContractLog[];
+}
+
+/** Guards the mirror-node re-scan against a pathological unbounded `links.next` chain. */
+const MIRROR_SCAN_MAX_PAGES = 50;
+
+async function fetchContractCallTransactions(): Promise<MirrorTransactionsPage["transactions"]> {
+  const all: MirrorTransactionsPage["transactions"] = [];
+  let path: string | null = "/api/v1/transactions?transactiontype=CONTRACTCALL&limit=100&order=asc";
+  let pages = 0;
+
+  while (path) {
+    if (++pages > MIRROR_SCAN_MAX_PAGES) {
+      throw new Error(
+        `hgraphFake: mirror-node transaction re-scan exceeded ${MIRROR_SCAN_MAX_PAGES} pages`,
+      );
+    }
+    const page: MirrorTransactionsPage = await fetchMirrorNode<MirrorTransactionsPage>(path);
+    all.push(...page.transactions);
+    path = page.links?.next ?? null;
+  }
+
+  // Top-level CONTRACTCALL only: findTransactionByContractCallV2 requires
+  // parent_consensus_timestamp === null too.
+  return all.filter(tx => tx.name === "CONTRACTCALL" && tx.parent_consensus_timestamp === null);
+}
+
+async function fetchLogsForTransaction(
+  tx: MirrorTransactionsPage["transactions"][number],
+): Promise<MirrorContractLog[]> {
+  if (!tx.entity_id) return [];
+  const page = await fetchMirrorNode<MirrorContractLogsPage>(
+    `/api/v1/contracts/${tx.entity_id}/results/logs?timestamp=eq:${tx.consensus_timestamp}`,
+  );
+  return page.logs;
+}
+
+/** The constructor mints via `Transfer(0x0, deployer, supply)`; zero address is handled explicitly
+ * since decoding it through the long-zero path would produce the wrong account num ("0.0.0"). */
+function buildTransferRow(
+  tx: MirrorTransactionsPage["transactions"][number],
+  log: MirrorContractLog,
+): FakeErcTokenTransfer | null {
+  const token = tokensByEvmAddress.get(log.address.toLowerCase());
+  if (!token) return null; // not one of ours
+
+  let decoded;
+  try {
+    decoded = decodeEventLog({
+      abi: erc20Abi,
+      data: log.data as `0x${string}`,
+      topics: log.topics as [`0x${string}`, ...`0x${string}`[]],
+    });
+  } catch {
+    return null; // not a Transfer-shaped log we understand (e.g. Approval)
+  }
+  if (decoded.eventName !== "Transfer") return null;
+
+  const { from, to, value } = decoded.args;
+  const fromIsZero = from.toLowerCase() === zeroAddress;
+  const toIsZero = to.toLowerCase() === zeroAddress;
+
+  return {
+    token_id: entityNum(token.contractId),
+    token_evm_address: token.evmAddress,
+    // decodeEventLog checksums addresses (EIP-55); lowercase to match token_evm_address/registry key.
+    sender_evm_address: fromIsZero ? null : from.toLowerCase(),
+    sender_account_id: fromIsZero ? null : longZeroToAccountNum(from),
+    receiver_evm_address: toIsZero ? null : to.toLowerCase(),
+    receiver_account_id: toIsZero ? null : longZeroToAccountNum(to),
+    payer_account_id: entityNum(tx.transaction_id.split("-")[0]),
+    amount: Number(value), // a future decimals bump could truncate a bigint amount silently
+    transfer_type: fromIsZero ? "mint" : toIsZero ? "burn" : "transfer",
+    consensus_timestamp: toNanosDigitString(tx.consensus_timestamp),
+    // transaction_id, not the mirror node's transaction_hash: the real REST API returns
+    // transaction_hash base64-encoded, but enrichERC20Transfers feeds this field straight into
+    // getContractCallResult, which only resolves a transaction id or a 32-byte hex hash.
+    transaction_hash: tx.transaction_id,
+  };
+}
+
+let transferSnapshot: FakeErcTokenTransfer[] | null = null;
+let transferPageCount = 0;
+
+/**
+ * Rebuilds the `erc_token_transfer` snapshot from the real mirror node. Called from the scenario's
+ * `beforeSync`, which runs outside the retry loop's try/catch, so a transient mirror-node error
+ * here (a 503, a connection reset) must not end the scenario outright: I/O failures are swallowed
+ * and the previous snapshot is kept, degrading into a retryable "transfer hasn't arrived yet"
+ * assertion failure instead. The page-guard counter only resets on success, so a never-initialised
+ * snapshot still throws its "queried before refresh()" guard rather than being masked.
+ */
+export async function refresh(): Promise<void> {
+  try {
+    const transactions = await fetchContractCallTransactions();
+    const rows: FakeErcTokenTransfer[] = [];
+
+    for (const tx of transactions) {
+      const logs = await fetchLogsForTransaction(tx);
+      for (const log of logs) {
+        const row = buildTransferRow(tx, log);
+        if (row) rows.push(row);
+      }
+    }
+
+    // Transactions are fetched order=asc for stable pagination, so sort desc here instead.
+    rows.sort((a, b) => {
+      const diff = BigInt(b.consensus_timestamp) - BigInt(a.consensus_timestamp);
+      return diff > 0n ? 1 : diff < 0n ? -1 : 0;
+    });
+    transferSnapshot = rows;
+    transferPageCount = 0;
+  } catch (err) {
+    console.error(
+      "hgraphFake: refresh() failed against the mirror node, keeping previous snapshot:",
+      err,
+    );
+  }
+}
+
+// getERC20Transfers always calls with fetchAllPages: true and no order/limit, which resolves to
+// "> cursor, sorted desc" — implemented faithfully here rather than defending against that.
+const MAX_TRANSFER_PAGES = 50;
+
+/**
+ * Handler-facing entry point for the `erc_token_transfer` query. Filters the frozen snapshot by
+ * token + account, applies the `> cursor` filter, sorts desc, slices to `limit`. Throws after
+ * `MAX_TRANSFER_PAGES` calls without an intervening `refresh()`, turning a client-side pagination
+ * hang into an immediate, named error instead of a 6-minute Jest timeout with no diagnostics.
+ */
+export function getErcTokenTransferRows({
+  accountId,
+  tokenEvmAddresses,
+  cursor,
+  limit,
+}: {
+  accountId: string;
+  tokenEvmAddresses: string[];
+  cursor?: string | null;
+  limit: number;
+}): FakeErcTokenTransfer[] {
+  if (transferSnapshot === null) {
+    throw new HgraphFakeGuardError(
+      "hgraphFake: erc_token_transfer queried before refresh() populated a snapshot",
+    );
+  }
+
+  transferPageCount += 1;
+  if (transferPageCount > MAX_TRANSFER_PAGES) {
+    throw new HgraphFakeGuardError(
+      `hgraphFake: erc_token_transfer exceeded ${MAX_TRANSFER_PAGES} pages since the last refresh() — ` +
+        "this is a guard against the fake looping forever, not real hgraph behaviour",
+    );
+  }
+
+  const tokenSet = new Set(tokenEvmAddresses.map(a => a.toLowerCase()));
+  const numericAccountId = Number(accountId);
+
+  let rows = transferSnapshot.filter(
+    row =>
+      tokenSet.has(row.token_evm_address.toLowerCase()) &&
+      (row.sender_account_id === numericAccountId || row.receiver_account_id === numericAccountId),
+  );
+
+  if (cursor != null) {
+    const cursorValue = BigInt(cursor);
+    rows = rows.filter(row => BigInt(row.consensus_timestamp) > cursorValue);
+  }
+
+  return rows.slice(0, limit); // already sorted desc by refresh()
+}
+
+// ethereum_transaction is answered live as max(latest contract result, wall clock). The wall-clock
+// floor matters because "hedera"/"hedera token"/"hedera staking" share one Solo cluster and run
+// before any contract exists, so an empty results page must not trip coin-hedera's
+// `invariant(..., "No transactions found in Hgraph")`.
+
+interface MirrorContractResultsPage {
+  results?: { timestamp: string }[];
+}
+
+async function fetchLatestContractResultNanos(): Promise<bigint | null> {
+  const page = await fetchMirrorNode<MirrorContractResultsPage>(
+    "/api/v1/contracts/results?limit=1&order=desc",
+  );
+  const timestamp = page.results?.[0]?.timestamp;
+  return timestamp ? toNanosBigInt(timestamp) : null;
+}
+
+/** Handler-facing entry point for the `ethereum_transaction` (latest indexed timestamp) query. */
+export async function getLatestEthereumTransactionTimestamp(): Promise<{
+  consensus_timestamp: string;
+}> {
+  const latestNanos = await fetchLatestContractResultNanos();
+  const wallClockNanos = BigInt(Date.now()) * 1_000_000n;
+  const floor = latestNanos !== null && latestNanos > wallClockNanos ? latestNanos : wallClockNanos;
+  return { consensus_timestamp: floor.toString() };
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/indexer.test.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/indexer.test.ts
@@ -1,0 +1,119 @@
+import { initMswHandlers } from "./indexer";
+import { FAKE_HGRAPH_URL, LOCAL_MIRROR_NODE_PORT } from "./fixtures";
+import { registerErc20Token, resetErc20Tokens } from "./hgraphFake";
+
+// This file tests msw wiring only — routing, the query/variables cross-check, and the
+// mirror-node-failure fallback. Mapping correctness (balances/transfers/timestamp shapes) is
+// covered by hgraphFake.test.ts and must not be duplicated here.
+
+describe("initMswHandlers", () => {
+  let close: () => void;
+
+  afterEach(() => {
+    close?.();
+    resetErc20Tokens();
+  });
+
+  it("answers getLatestIndexedConsensusTimestamp with a non-empty ethereum_transaction row", async () => {
+    close = initMswHandlers();
+
+    const res = await fetch(FAKE_HGRAPH_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: "query LatestTransaction { ethereum_transaction(limit: 1) { consensus_timestamp } }",
+      }),
+    });
+    const body = await res.json();
+
+    expect(body.data.ethereum_transaction).toHaveLength(1);
+    expect(body.data.ethereum_transaction[0].consensus_timestamp).toBeDefined();
+  });
+
+  it("routes a request with { accountId } variables to the erc_token_account branch", async () => {
+    close = initMswHandlers();
+
+    const res = await fetch(FAKE_HGRAPH_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: "query GetAccountPortfolio($accountId: bigint!) { erc_token_account { token_id } }",
+        variables: { accountId: "1002" },
+      }),
+    });
+    const body = await res.json();
+
+    expect(body).toEqual({ data: { erc_token_account: [] } });
+  });
+
+  it("routes a request with { tokenEvmAddresses } variables to the erc_token_transfer branch, and lets a guard error propagate loudly instead of swallowing it", async () => {
+    close = initMswHandlers();
+
+    // No refresh() has run, so hgraphFake throws its "queried before refresh()" guard, which the
+    // handler must rethrow rather than swallow into an empty response.
+    const res = await fetch(FAKE_HGRAPH_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query:
+          "query GetAccountTransfers($accountId: bigint!, $tokenEvmAddresses: [String!]!, $limit: Int!) { erc_token_transfer { token_id } }",
+        variables: { accountId: "1002", tokenEvmAddresses: ["0xabc"], limit: 100 },
+      }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.message).toMatch(
+      /erc_token_transfer queried before refresh\(\) populated a snapshot/,
+    );
+  });
+
+  it("returns a well-formed empty erc_token_account response when the mirror node fetch fails", async () => {
+    close = initMswHandlers();
+    // No Solo cluster is running here, so this balance lookup hits a real, unmocked mirror-node
+    // port and fails with a genuine connection error.
+    registerErc20Token("0.0.5005", "0x1111111111111111111111111111111111111111");
+
+    const res = await fetch(FAKE_HGRAPH_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: "query GetAccountPortfolio($accountId: bigint!) { erc_token_account { token_id } }",
+        variables: { accountId: "1002" },
+      }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ data: { erc_token_account: [] } });
+  });
+
+  it("throws a named routing-mismatch error when the query text doesn't match the picked branch", async () => {
+    close = initMswHandlers();
+
+    const res = await fetch(FAKE_HGRAPH_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        // variables look like the erc_token_account branch, but the query text names none of it.
+        query: "query Unrelated { something { field } }",
+        variables: { accountId: "1002" },
+      }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.message).toMatch(/routed this request to hgraphFake's "erc_token_account" branch/);
+  });
+
+  it("rejects a localhost request on a non-mirror-node port instead of waving it through", async () => {
+    close = initMswHandlers();
+    const otherPort = `${Number(LOCAL_MIRROR_NODE_PORT) + 1}`;
+
+    const res = await fetch(`http://127.0.0.1:${otherPort}/anything`);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.message).toMatch(/Unhandled MSW request/);
+  });
+});

--- a/libs/coin-tester-modules/coin-tester-hedera/src/indexer.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/indexer.ts
@@ -1,0 +1,133 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { FAKE_HGRAPH_URL, HBAR_USD_RATE, HEDERA, LOCAL_MIRROR_NODE_PORT } from "./fixtures";
+import {
+  getErcTokenAccountRows,
+  getErcTokenTransferRows,
+  getLatestEthereumTransactionTimestamp,
+  HgraphFakeGuardError,
+} from "./hgraphFake";
+
+const observer = { callCount: 0, queries: [] as string[] };
+
+export function getHgraphObserver(): { callCount: number; queries: string[] } {
+  return observer;
+}
+
+interface HgraphRequestBody {
+  query?: string;
+  variables?: Record<string, unknown>;
+}
+
+/**
+ * Cross-checks the branch picked from `variables` against the query text's root field, so a query
+ * shape this fake doesn't recognize (e.g. `getERC20TransfersByTimestampRange`, currently unreachable
+ * from the sync path) fails loudly here instead of silently misrouting into the wrong branch.
+ */
+function assertQueryNamesRootField(query: string, rootField: string): void {
+  if (!query.includes(rootField)) {
+    throw new Error(
+      `indexer.ts: routed this request to hgraphFake's "${rootField}" branch based on its ` +
+        `variables, but the query text does not mention "${rootField}" — routing/variables shape ` +
+        `mismatch. Query was: ${query}`,
+    );
+  }
+}
+
+function wellFormedEmpty(rootField: "erc_token_account" | "erc_token_transfer"): Response {
+  return HttpResponse.json({ data: { [rootField]: [] } });
+}
+
+async function hgraphHandler(request: Request): Promise<Response> {
+  const body = (await request.clone().json()) as HgraphRequestBody;
+  const query = body.query ?? "";
+  const variables = body.variables ?? {};
+
+  observer.callCount += 1;
+  observer.queries.push(query);
+
+  // Routing is on `variables` shape: erc_token_transfer has tokenEvmAddresses, erc_token_account
+  // has accountId only, ethereum_transaction has no variables key at all.
+  if ("tokenEvmAddresses" in variables) {
+    assertQueryNamesRootField(query, "erc_token_transfer");
+    try {
+      const rows = await getErcTokenTransferRows(
+        variables as {
+          accountId: string;
+          tokenEvmAddresses: string[];
+          cursor?: string | null;
+          limit: number;
+        },
+      );
+      return HttpResponse.json({ data: { erc_token_transfer: rows } });
+    } catch (err) {
+      // Guard throws (bugs in us) stay loud; I/O failures (mirror node down) degrade quietly.
+      if (err instanceof HgraphFakeGuardError) throw err;
+      console.error("indexer.ts: erc_token_transfer lookup against the mirror node failed:", err);
+      return wellFormedEmpty("erc_token_transfer");
+    }
+  }
+
+  if ("accountId" in variables) {
+    assertQueryNamesRootField(query, "erc_token_account");
+    try {
+      const rows = await getErcTokenAccountRows(variables as { accountId: string });
+      return HttpResponse.json({ data: { erc_token_account: rows } });
+    } catch (err) {
+      if (err instanceof HgraphFakeGuardError) throw err;
+      console.error("indexer.ts: erc_token_account lookup against the mirror node failed:", err);
+      return wellFormedEmpty("erc_token_account");
+    }
+  }
+
+  assertQueryNamesRootField(query, "ethereum_transaction");
+  try {
+    const row = await getLatestEthereumTransactionTimestamp();
+    // getLatestIndexedConsensusTimestamp reads ethereum_transaction[0]?.consensus_timestamp, so it
+    // must be wrapped as the single element of an array here.
+    return HttpResponse.json({ data: { ethereum_transaction: [row] } });
+  } catch (err) {
+    if (err instanceof HgraphFakeGuardError) throw err;
+    console.error(
+      "indexer.ts: ethereum_transaction (latest indexed timestamp) lookup against the mirror node failed:",
+      err,
+    );
+    // Must never be empty even on failure: coin-hedera's invariant("No transactions found in
+    // Hgraph") would otherwise trip. Wall clock is a safe floor.
+    const wallClockNanos = BigInt(Date.now()) * 1_000_000n;
+    return HttpResponse.json({
+      data: { ethereum_transaction: [{ consensus_timestamp: wallClockNanos.toString() }] },
+    });
+  }
+}
+
+export function initMswHandlers(): () => void {
+  observer.callCount = 0;
+  observer.queries = [];
+
+  const server = setupServer(
+    http.post(FAKE_HGRAPH_URL, ({ request }) => hgraphHandler(request)),
+    http.get("https://global.api.prd.ledger.com/cal/*", () => HttpResponse.json([])),
+    http.get("https://nft.api.live.ledger.com/*", () => HttpResponse.json([])),
+    http.get("https://earn.api.live.ledger.com/*", () => HttpResponse.json([])),
+    // Must be a real number: an empty response makes estimateFees fall back to
+    // DEFAULT_TINYBAR_FEE and fails the HEDERA_TOKEN_ASSOCIATION_MIN_USD check.
+    http.get("https://countervalues.live.ledger.com/v3/spot/simple", () =>
+      HttpResponse.json({ [HEDERA.id]: HBAR_USD_RATE }),
+    ),
+  );
+
+  server.listen({
+    onUnhandledRequest: req => {
+      const { hostname, port } = new URL(req.url);
+      // Real local mirror node (Solo) and the fake's own fetches into it must pass through
+      // unmocked; narrowed to that port so no other localhost traffic is waved through silently.
+      if (["127.0.0.1", "localhost"].includes(hostname) && port === LOCAL_MIRROR_NODE_PORT) {
+        return;
+      }
+      throw new Error(`Unhandled MSW request: ${req.method} ${req.url}`);
+    },
+  });
+
+  return () => server.close();
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/negativeCases.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/negativeCases.ts
@@ -1,0 +1,301 @@
+import BigNumber from "bignumber.js";
+import type { AccountBridge } from "@ledgerhq/types-live";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import type { Transaction, HederaAccount, TransactionStatus } from "@ledgerhq/coin-hedera/types";
+import { HEDERA_MAX_MEMO_SIZE } from "@ledgerhq/coin-hedera/logic/validateMemo";
+import { encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account";
+import {
+  MAX_AUTO_ASSOCIATIONS,
+  ONE_HBAR_IN_TINYBAR,
+  TOKEN_DECIMALS,
+  TOKEN_SYMBOL,
+  TOKEN_UNIT,
+  RECIPIENT,
+  makeHederaAccount,
+  makeLocalHtsToken,
+  makeLocalErc20Token,
+} from "./fixtures";
+import { setupHederaScenario } from "./helpers";
+import {
+  createHtsToken,
+  transferToken,
+  waitForMirrorNodeTokenBalance,
+  deployErc20Token,
+  transferErc20,
+  waitForErc20Balance,
+  waitForMirrorNodeEvmAddress,
+} from "./genesis";
+import { registerErc20Token, resetErc20Tokens, refresh } from "./hgraphFake";
+
+const TOKEN_INITIAL_SUPPLY = 1_000 * TOKEN_UNIT;
+const TOKEN_INJECTED = 100 * TOKEN_UNIT;
+const ERC20_SEED_AMOUNT = 100 * TOKEN_UNIT;
+const NEGATIVE_CASES_SETUP_TIMEOUT_MS = 120_000;
+
+// toEVMAddress returns null for a nonexistent account, reaching the craft-time invariant.
+// RECIPIENT (0.0.1002) won't do: it has no alias, so the mirror node reports a long-zero
+// evm_address for it instead.
+const NONEXISTENT_RECIPIENT = "0.0.999999999";
+
+async function syncAccount(
+  accountBridge: AccountBridge<Transaction, HederaAccount, TransactionStatus>,
+  initial: HederaAccount,
+): Promise<HederaAccount> {
+  return new Promise<HederaAccount>((resolve, reject) => {
+    let acc = initial;
+    accountBridge.sync(initial, { paginationConfig: {} }).subscribe({
+      next: (update: (a: HederaAccount) => HederaAccount) => {
+        acc = update(acc);
+      },
+      error: reject,
+      complete: () => resolve(acc),
+    });
+  });
+}
+
+async function buildStatusFor(
+  accountBridge: AccountBridge<Transaction, HederaAccount, TransactionStatus>,
+  account: HederaAccount,
+  patch: Partial<Transaction>,
+): Promise<TransactionStatus> {
+  let tx = accountBridge.createTransaction(account);
+  tx = { ...tx, ...patch } as Transaction;
+  tx = await accountBridge.prepareTransaction(account, tx);
+  return accountBridge.getTransactionStatus(account, tx);
+}
+
+// Call from inside scenarii.test.ts's `describe("Hedera")` so it shares that Solo cluster.
+export function describeNegativeCases(): void {
+  describe("negative cases", () => {
+    let closeMswHandlers: (() => void) | undefined;
+    let accountBridge: AccountBridge<Transaction, HederaAccount, TransactionStatus>;
+    let account: HederaAccount;
+    let token: TokenCurrency;
+    let tokenSubAccountId: string;
+
+    beforeAll(async () => {
+      const tokenId = await createHtsToken({
+        decimals: TOKEN_DECIMALS,
+        symbol: TOKEN_SYMBOL,
+        initialSupply: TOKEN_INITIAL_SUPPLY,
+      });
+      token = makeLocalHtsToken(tokenId);
+
+      const {
+        currencyBridge,
+        accountBridge: ab,
+        publicKey,
+        accountId,
+        close,
+      } = await setupHederaScenario([token], MAX_AUTO_ASSOCIATIONS);
+      closeMswHandlers = close;
+      accountBridge = ab;
+
+      await transferToken(tokenId, accountId, TOKEN_INJECTED);
+      await waitForMirrorNodeTokenBalance(accountId, tokenId, TOKEN_INJECTED);
+
+      const initial = makeHederaAccount(accountId, publicKey);
+      if (currencyBridge.preload) {
+        const data = await currencyBridge.preload(initial.currency);
+        currencyBridge.hydrate?.(data, initial.currency);
+      }
+
+      account = await syncAccount(accountBridge, initial);
+
+      tokenSubAccountId = encodeTokenAccountId(account.id, token);
+    }, NEGATIVE_CASES_SETUP_TIMEOUT_MS);
+
+    afterAll(() => {
+      // The parent `afterAll` in scenarii.test.ts still runs last and owns teardownSolo.
+      closeMswHandlers?.();
+    });
+
+    const buildStatus = (patch: Partial<Transaction>): Promise<TransactionStatus> =>
+      buildStatusFor(accountBridge, account, patch);
+
+    it("flags insufficient funds (NotEnoughBalance)", async () => {
+      const status = await buildStatus({
+        recipient: RECIPIENT,
+        amount: account.balance.plus(ONE_HBAR_IN_TINYBAR),
+      });
+      expect(status.errors.amount?.name).toBe("NotEnoughBalance");
+    });
+
+    it("flags a malformed recipient accountId (InvalidAddress)", async () => {
+      const status = await buildStatus({
+        recipient: "not-an-account",
+        amount: new BigNumber(ONE_HBAR_IN_TINYBAR),
+      });
+      expect(status.errors.recipient?.name).toBe("InvalidAddress");
+    });
+
+    it("warns on an HTS transfer to an unassociated recipient (HederaRecipientTokenAssociationRequired)", async () => {
+      const status = await buildStatus({
+        subAccountId: tokenSubAccountId,
+        recipient: RECIPIENT, // 0.0.1002 exists but is NOT associated with this token
+        amount: new BigNumber(TOKEN_UNIT),
+      });
+      expect(status.warnings.missingAssociation?.name).toBe(
+        "HederaRecipientTokenAssociationRequired",
+      );
+    });
+
+    it("flags an HTS transfer above the held token balance (NotEnoughBalance)", async () => {
+      const status = await buildStatus({
+        subAccountId: tokenSubAccountId,
+        recipient: RECIPIENT,
+        amount: new BigNumber(TOKEN_INJECTED + TOKEN_UNIT),
+      });
+      expect(status.errors.amount?.name).toBe("NotEnoughBalance");
+    });
+
+    // Deploys its own ERC20 contract instead of reusing scenarioHederaErc20's, so this block
+    // doesn't depend on that scenario having run first.
+    describe("erc20 negative cases", () => {
+      let closeErc20MswHandlers: (() => void) | undefined;
+      let erc20AccountBridge: AccountBridge<Transaction, HederaAccount, TransactionStatus>;
+      let erc20Account: HederaAccount;
+      let erc20TokenSubAccountId: string;
+
+      beforeAll(async () => {
+        // The token must be registered right after deploy: the hgraph-fake registry reset isn't
+        // wired into initMswHandlers.
+        const { contractId, evmAddress } = await deployErc20Token();
+        registerErc20Token(contractId, evmAddress);
+
+        const erc20Token = makeLocalErc20Token(evmAddress);
+
+        // Jest runs all outer `it`s before this nested `describe`, so this second msw server
+        // never overlaps with the outer block's.
+        const {
+          currencyBridge,
+          accountBridge: ab,
+          publicKey,
+          accountId,
+          close,
+        } = await setupHederaScenario([token, erc20Token], MAX_AUTO_ASSOCIATIONS);
+        closeErc20MswHandlers = close;
+        erc20AccountBridge = ab;
+
+        const accountEvmAddress = await waitForMirrorNodeEvmAddress(accountId);
+
+        // Fund the account under test directly from the genesis operator, bypassing the bridge.
+        await transferErc20(evmAddress, accountEvmAddress, ERC20_SEED_AMOUNT);
+
+        // The seed must be confirmed as a balance, not a transfer: only addresses with a balance
+        // row enter calTokenByAddress, which the transfer feed is derived from.
+        await waitForErc20Balance(evmAddress, accountEvmAddress, ERC20_SEED_AMOUNT);
+
+        // No beforeSync in this block, so refresh() must run explicitly before the sync below.
+        await refresh();
+
+        const initial = makeHederaAccount(accountId, publicKey);
+
+        // Re-runs preload/hydrate against this setup's currencyBridge (token list [token,
+        // erc20Token]): the outer beforeAll's only covered the HTS token.
+        if (currencyBridge.preload) {
+          const data = await currencyBridge.preload(initial.currency);
+          currencyBridge.hydrate?.(data, initial.currency);
+        }
+
+        erc20Account = await syncAccount(erc20AccountBridge, initial);
+
+        erc20TokenSubAccountId = encodeTokenAccountId(erc20Account.id, erc20Token);
+
+        expect(erc20Account.subAccounts?.some(sa => sa.id === erc20TokenSubAccountId)).toBe(true);
+      }, NEGATIVE_CASES_SETUP_TIMEOUT_MS);
+
+      afterAll(() => {
+        // The parent `afterAll` in scenarii.test.ts still runs last and owns teardownSolo.
+        closeErc20MswHandlers?.();
+        resetErc20Tokens();
+      });
+
+      it("flags an ERC20 transfer above the held token balance (NotEnoughBalance)", async () => {
+        // RECIPIENT is safe here: this only exercises status/validation, which never reaches
+        // the craft-time toEVMAddress invariant.
+        const status = await buildStatusFor(erc20AccountBridge, erc20Account, {
+          subAccountId: erc20TokenSubAccountId,
+          recipient: RECIPIENT,
+          amount: new BigNumber(ERC20_SEED_AMOUNT + TOKEN_UNIT),
+        });
+
+        expect(status.errors.amount?.name).toBe("NotEnoughBalance");
+        // Not a validation rule: handleERC20TokenTransaction sets this warning unconditionally.
+        expect(status.warnings.unverifiedEvmAddress?.name).toBe(
+          "HederaRecipientEvmAddressVerificationRequired",
+        );
+      });
+
+      it("flags a zero-amount ERC20 transfer (AmountRequired)", async () => {
+        const status = await buildStatusFor(erc20AccountBridge, erc20Account, {
+          subAccountId: erc20TokenSubAccountId,
+          recipient: RECIPIENT,
+          amount: new BigNumber(0),
+        });
+
+        expect(status.errors.amount?.name).toBe("AmountRequired");
+      });
+
+      it("flags an over-long ERC20 memo (HederaMemoExceededSizeError)", async () => {
+        const status = await buildStatusFor(erc20AccountBridge, erc20Account, {
+          subAccountId: erc20TokenSubAccountId,
+          recipient: RECIPIENT,
+          amount: new BigNumber(TOKEN_UNIT),
+          memo: "x".repeat(HEDERA_MAX_MEMO_SIZE + 1),
+        });
+
+        expect(status.errors.transaction?.name).toBe("HederaMemoExceededSizeError");
+      });
+
+      it("flags a malformed recipient on the ERC20 branch (InvalidAddress)", async () => {
+        const status = await buildStatusFor(erc20AccountBridge, erc20Account, {
+          subAccountId: erc20TokenSubAccountId,
+          recipient: "not-an-account",
+          amount: new BigNumber(TOKEN_UNIT),
+        });
+
+        expect(status.errors.recipient?.name).toBe("InvalidAddress");
+      });
+
+      it("flags an ERC20 transfer with no HBAR left to pay gas (NotEnoughBalance)", async () => {
+        // In-memory only: buildStatusFor takes the account as data, so a shallow copy with a
+        // 1-tinybar balance is enough.
+        const noGasAccount = { ...erc20Account, balance: new BigNumber(1) };
+
+        // amount must stay inside the sub-account balance: both that check and the parent HBAR
+        // check write errors.amount, so an over-balance amount would pass for the wrong reason.
+        const status = await buildStatusFor(erc20AccountBridge, noGasAccount, {
+          subAccountId: erc20TokenSubAccountId,
+          recipient: RECIPIENT,
+          amount: new BigNumber(TOKEN_UNIT),
+        });
+
+        expect(status.errors.amount?.name).toBe("NotEnoughBalance");
+      });
+
+      it("rejects crafting an ERC20 transfer to a recipient with no evm_address", async () => {
+        let transaction = erc20AccountBridge.createTransaction(erc20Account);
+        transaction = {
+          ...transaction,
+          subAccountId: erc20TokenSubAccountId,
+          recipient: NONEXISTENT_RECIPIENT,
+          amount: new BigNumber(TOKEN_UNIT),
+        } as Transaction;
+        transaction = await erc20AccountBridge.prepareTransaction(erc20Account, transaction);
+
+        // signOperation calls craftTransaction directly, skipping getTransactionStatus — this is
+        // the only reachable assertion for the craft-time invariant.
+        const signed = new Promise<void>((resolve, reject) => {
+          erc20AccountBridge
+            .signOperation({ account: erc20Account, transaction, deviceId: "" })
+            .subscribe({ next: () => {}, error: reject, complete: () => resolve() });
+        });
+
+        await expect(signed).rejects.toThrow(
+          `hedera: EVM address is missing ${NONEXISTENT_RECIPIENT}`,
+        );
+      });
+    });
+  });
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/scenarii.test.ts
@@ -1,0 +1,63 @@
+import type { TransactionCommon } from "@ledgerhq/types-live";
+import { executeScenario } from "@ledgerhq/coin-tester/main";
+import { closeGenesisClient } from "./genesis";
+import { deploySolo, teardownSolo } from "./solo";
+import { legacyTarget } from "./helpers";
+import { genericTarget } from "./genericHelpers";
+import type { HederaBridgeTarget } from "./bridgeTarget";
+import { makeScenarioHedera } from "./scenarii/hedera";
+import { makeScenarioHederaToken } from "./scenarii/hederaToken";
+import { makeScenarioHederaStaking } from "./scenarii/hederaStaking";
+import { makeScenarioHederaMultiToken } from "./scenarii/hederaMultiToken";
+import { makeScenarioHederaErc20 } from "./scenarii/hederaErc20";
+import { makeScenarioHederaErc20Receive } from "./scenarii/hederaErc20Receive";
+import { describeNegativeCases } from "./negativeCases";
+
+/** Solo cold start is 7–10 min; the hook gets its own budget so it is not charged to a scenario. */
+const CLUSTER_BRING_UP_TIMEOUT_MS = 900_000;
+
+// Per *test*, not per suite: a hung scenario fails in 6 min.
+jest.setTimeout(360_000);
+
+["exit", "SIGINT", "SIGQUIT", "SIGTERM", "SIGUSR1", "SIGUSR2", "uncaughtException"].forEach(e =>
+  process.on(e, async () => {
+    closeGenesisClient();
+    await teardownSolo();
+  }),
+);
+
+/** Runs the full scenario suite against one bridge, `T` fixed for the whole run so every
+ * `makeScenarioX(target)` call below builds that bridge's own transaction type. */
+function runHederaScenarios<T extends TransactionCommon>(
+  label: string,
+  target: HederaBridgeTarget<T>,
+) {
+  describe(`scenarios (${label} bridge)`, () => {
+    it("scenario hedera", () => executeScenario(makeScenarioHedera(target)));
+    it("scenario hedera token", () => executeScenario(makeScenarioHederaToken(target)));
+    it("scenario hedera staking", () => executeScenario(makeScenarioHederaStaking(target)));
+
+    it("scenario hedera token multi", () =>
+      executeScenario(makeScenarioHederaMultiToken(target)));
+    it("scenario hedera erc20", () => executeScenario(makeScenarioHederaErc20(target)));
+    it("scenario hedera erc20 receive", () =>
+      executeScenario(makeScenarioHederaErc20Receive(target)));
+  });
+}
+
+describe("Hedera", () => {
+  beforeAll(async () => {
+    await deploySolo();
+  }, CLUSTER_BRING_UP_TIMEOUT_MS);
+
+  // The three scenarios share one cluster, so no individual scenario may tear it down.
+  afterAll(async () => {
+    closeGenesisClient();
+    await teardownSolo();
+  });
+
+  runHederaScenarios("legacy", legacyTarget);
+  runHederaScenarios("generic", genericTarget);
+
+  describeNegativeCases();
+});

--- a/libs/coin-tester-modules/coin-tester-hedera/src/scenarii/hedera.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/scenarii/hedera.ts
@@ -1,0 +1,135 @@
+import { PrivateKey } from "@hashgraph/sdk";
+import type { Scenario } from "@ledgerhq/coin-tester/main";
+import type { TransactionCommon } from "@ledgerhq/types-live";
+import type { HederaAccount, HederaOperationExtra } from "@ledgerhq/coin-hedera/types";
+import BigNumber from "bignumber.js";
+import { ONE_HBAR_IN_TINYBAR, RECIPIENT, makeHederaAccount } from "../fixtures";
+import { SCENARIO_RETRY_POLICY } from "../helpers";
+import type { HederaBridgeTarget } from "../bridgeTarget";
+import type { CanonicalHederaTransaction } from "../canonicalTransaction";
+import { getHgraphObserver } from "../indexer";
+
+let closeMswHandlers: (() => void) | undefined;
+
+function makeTransactions(): CanonicalHederaTransaction[] {
+  // A never-funded ED25519 alias; sending HBAR to it exercises Hedera's auto-account-creation.
+  // Generated per scenario run, not per module load: the suite runs this scenario once per
+  // bridge, and the first run turns the alias into a real account, so a shared alias would leave
+  // the second run with a plain transfer and no CRYPTOCREATEACCOUNT child transaction.
+  const autoCreateAlias = PrivateKey.generateED25519().publicKey.toAccountId(0, 0).toString();
+
+  const sendOneHbar: CanonicalHederaTransaction = {
+    name: "Send 1 HBAR to an existing recipient",
+    mode: "send",
+    amount: new BigNumber(ONE_HBAR_IN_TINYBAR),
+    recipient: RECIPIENT,
+    expect: (previous, current) => {
+      expect(current.operations.length).toBeGreaterThan(0);
+      const [latest] = current.operations;
+      expect(latest.type).toBe("OUT");
+      expect(latest.recipients).toContain(RECIPIENT);
+      // `value` is fee-inclusive; subtracting `fee` too would double-count it.
+      expect(current.balance).toStrictEqual(previous.balance.minus(latest.value));
+    },
+  };
+
+  const sendOneHbarWithMemo: CanonicalHederaTransaction = {
+    name: "Send 1 HBAR with a memo to an existing recipient",
+    mode: "send",
+    amount: new BigNumber(ONE_HBAR_IN_TINYBAR),
+    recipient: RECIPIENT,
+    memo: "ledger-live e2e",
+    expect: (previous, current) => {
+      expect(current.operations.length).toBeGreaterThan(0);
+      const [latest] = current.operations;
+      expect(latest.type).toBe("OUT");
+      expect(latest.recipients).toContain(RECIPIENT);
+      expect(current.balance).toStrictEqual(previous.balance.minus(latest.value));
+      const memoExtra = latest.extra as HederaOperationExtra;
+      expect(memoExtra.memo).toBeDefined();
+      expect(memoExtra.memo).toBe("ledger-live e2e");
+    },
+  };
+
+  const sendToAutoCreatedAccount: CanonicalHederaTransaction = {
+    name: "Send 1 HBAR to a fresh alias (auto-creates the recipient account)",
+    mode: "send",
+    amount: new BigNumber(ONE_HBAR_IN_TINYBAR),
+    recipient: autoCreateAlias,
+    expect: (previous, current) => {
+      // Auto-creation bills the sender through two mirror-node transactions (CRYPTOTRANSFER +
+      // CRYPTOCREATEACCOUNT), both as OUT operations.
+      const previousIds = new Set(previous.operations.map(op => op.id));
+      const created = current.operations.filter(op => !previousIds.has(op.id));
+      expect(created.length).toBe(2);
+      const transfer = created.find(op => op.value.minus(op.fee).isEqualTo(ONE_HBAR_IN_TINYBAR));
+      const accountCreation = created.find(op => op.value.isEqualTo(op.fee));
+      expect(transfer).toBeDefined();
+      expect(accountCreation).toBeDefined();
+      if (!transfer || !accountCreation) return;
+      expect(transfer.type).toBe("OUT");
+      // A resolved numeric recipient (0.0.N, never the alias hex) proves the alias auto-created.
+      expect(transfer.recipients.some(r => /^0\.0\.\d+$/.test(r))).toBe(true);
+      expect(accountCreation.type).toBe("OUT");
+      expect(accountCreation.value.isGreaterThan(0)).toBe(true);
+      expect(current.balance).toStrictEqual(
+        previous.balance.minus(transfer.value).minus(accountCreation.value),
+      );
+    },
+  };
+
+  const sendMaxHbar: CanonicalHederaTransaction = {
+    name: "Send max HBAR (drains the account)",
+    mode: "send",
+    useAllAmount: true,
+    recipient: RECIPIENT,
+    expect: (previous, current) => {
+      expect(current.operations.length).toBeGreaterThan(previous.operations.length);
+      const [latest] = current.operations;
+      expect(latest.type).toBe("OUT");
+      expect(latest.recipients).toContain(RECIPIENT);
+      expect(current.balance).toStrictEqual(previous.balance.minus(latest.value));
+      // Send max leaves behind the fee *estimate* minus the actual fee charged — never zero.
+      expect(current.balance.toNumber()).toBeLessThanOrEqual(
+        latest.fee.multipliedBy(10).toNumber(),
+      );
+      // Catches an ignored `useAllAmount`: the residual would then be most of the prior balance.
+      expect(current.balance.toNumber()).toBeLessThan(previous.balance.toNumber() * 0.01);
+    },
+  };
+
+  return [sendOneHbar, sendOneHbarWithMemo, sendToAutoCreatedAccount, sendMaxHbar];
+}
+
+export function makeScenarioHedera<T extends TransactionCommon>(
+  target: HederaBridgeTarget<T>,
+): Scenario<T, HederaAccount> {
+  return {
+    name: "Ledger Live Hedera — native HBAR sends",
+
+    setup: async () => {
+      const { currencyBridge, accountBridge, publicKey, accountId, close } = await target.setup([]);
+      closeMswHandlers = close;
+
+      return {
+        currencyBridge,
+        accountBridge,
+        account: makeHederaAccount(accountId, publicKey),
+        ...SCENARIO_RETRY_POLICY,
+      };
+    },
+
+    getTransactions: () => makeTransactions().map(target.toTransaction),
+
+    afterAll: () => {
+      const observer = getHgraphObserver();
+      console.warn(
+        `hgraph observer: ${observer.callCount} call(s) — ${observer.queries.join(" | ")}`,
+      );
+    },
+
+    teardown: () => {
+      closeMswHandlers?.();
+    },
+  };
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/scenarii/hederaErc20.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/scenarii/hederaErc20.ts
@@ -1,0 +1,209 @@
+import { PrivateKey } from "@hashgraph/sdk";
+import type { Scenario } from "@ledgerhq/coin-tester/main";
+import type { HederaAccount, HederaOperationExtra } from "@ledgerhq/coin-hedera/types";
+import { DEFAULT_GAS_LIMIT } from "@ledgerhq/coin-hedera/constants";
+import type { TokenAccount, TransactionCommon } from "@ledgerhq/types-live";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import { encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account";
+import BigNumber from "bignumber.js";
+import { TOKEN_SYMBOL, TOKEN_UNIT, makeHederaAccount, makeLocalErc20Token } from "../fixtures";
+import { SCENARIO_RETRY_POLICY, findTokenSubAccount } from "../helpers";
+import type { HederaBridgeTarget } from "../bridgeTarget";
+import type { CanonicalHederaTransaction } from "../canonicalTransaction";
+import {
+  createFundedAccount,
+  deployErc20Token,
+  transferErc20,
+  waitForErc20Balance,
+  waitForMirrorNodeEvmAddress,
+} from "../genesis";
+import { registerErc20Token, resetErc20Tokens, refresh } from "../hgraphFake";
+
+// A zero-balance ERC20 sub-account with no operations gets dropped by the bridge, so the seed
+// must not hit zero on the first send (send-max, later, drains it once it has operations).
+const SEED_AMOUNT = 100 * TOKEN_UNIT;
+const SEND_AMOUNT = 10 * TOKEN_UNIT;
+const MEMO_SEND_AMOUNT = 5 * TOKEN_UNIT;
+/** What is left after the two fixed sends; send-max must drain exactly this. */
+const SEND_MAX_AMOUNT = SEED_AMOUNT - SEND_AMOUNT - MEMO_SEND_AMOUNT;
+const MEMO = "ledger-live coin-tester erc20 memo";
+
+let closeMswHandlers: (() => void) | undefined;
+let token: TokenCurrency;
+let evmAddress: string;
+let accountId: string;
+let recipientId: string;
+
+function findErc20SubAccount(account: HederaAccount): TokenAccount | undefined {
+  return findTokenSubAccount(account, token.id);
+}
+
+function makeTransactions(): CanonicalHederaTransaction[] {
+  const sendErc20: CanonicalHederaTransaction = {
+    name: `Send ${SEND_AMOUNT / TOKEN_UNIT} ${TOKEN_SYMBOL} (ERC20)`,
+    mode: "send",
+    subAccountId: encodeTokenAccountId(makeHederaAccount(accountId, "").id, token),
+    amount: new BigNumber(SEND_AMOUNT),
+    recipient: recipientId,
+    expect: (previous, current) => {
+      const previousSub = findErc20SubAccount(previous);
+      const currentSub = findErc20SubAccount(current);
+      expect(previousSub).toBeDefined();
+      expect(currentSub).toBeDefined();
+      if (!previousSub || !currentSub) return; // retryable: mirror-node/hgraph-fake lag, not a TypeError
+
+      // previous must already carry the genesis seed as an IN operation: it's an incoming ERC20
+      // transfer, and the opening beforeSync refreshed the snapshot before the first sync.
+      const seedIn = previousSub.operations.find(op => op.type === "IN");
+      expect(seedIn).toBeDefined();
+      if (!seedIn) return;
+      expect(seedIn.value.toString()).toBe(String(SEED_AMOUNT));
+
+      expect(currentSub.balance.toString()).toBe(previousSub.balance.minus(SEND_AMOUNT).toString());
+
+      const [latestSub] = currentSub.operations;
+      expect(latestSub).toBeDefined();
+      if (!latestSub) return;
+      expect(latestSub.type).toBe("OUT");
+      expect(latestSub.value.toString()).toBe(String(SEND_AMOUNT));
+
+      // A FEES operation on the parent account with the same hash proves both the ERC20 branch
+      // and that CAL resolution worked: resolveBridgeOperations only keeps FEES when the token
+      // operation resolved through CAL.
+      const feesOpHashes = current.operations.filter(op => op.type === "FEES").map(op => op.hash);
+      expect(feesOpHashes).toContain(latestSub.hash);
+
+      // extra.gasLimit is the on-chain gas limit from the mirror node, proof the estimate survived
+      // crafting/signing/broadcast. No upper bound asserted: Solo's intrinsic-cost overhead on top
+      // of the ~60k estimate is unmeasured.
+      const { gasLimit } = latestSub.extra as HederaOperationExtra;
+      // A bare `expect(undefined).toBeGreaterThan(0)` would escape the runner's retry wrapper
+      // and kill the scenario outright.
+      expect(typeof gasLimit).toBe("number");
+      if (typeof gasLimit !== "number") return;
+      expect(gasLimit).not.toBe(DEFAULT_GAS_LIMIT.toNumber());
+      expect(gasLimit).toBeGreaterThan(0);
+    },
+  };
+
+  const sendErc20WithMemo: CanonicalHederaTransaction = {
+    name: `Send ${MEMO_SEND_AMOUNT / TOKEN_UNIT} ${TOKEN_SYMBOL} (ERC20) with a memo`,
+    mode: "send",
+    subAccountId: encodeTokenAccountId(makeHederaAccount(accountId, "").id, token),
+    amount: new BigNumber(MEMO_SEND_AMOUNT),
+    recipient: recipientId,
+    memo: MEMO,
+    expect: (previous, current) => {
+      const currentSub = findErc20SubAccount(current);
+      expect(currentSub).toBeDefined();
+      if (!currentSub) return;
+
+      // Absolute, not a delta off `previous`: `previous` is frozen at this transaction's opening
+      // sync and never re-read on retry, so a lagging snapshot there would fail forever.
+      expect(currentSub.balance.toString()).toBe(
+        String(SEED_AMOUNT - SEND_AMOUNT - MEMO_SEND_AMOUNT),
+      );
+
+      const [latestSub] = currentSub.operations;
+      expect(latestSub).toBeDefined();
+      if (!latestSub) return;
+      expect(latestSub.type).toBe("OUT");
+      expect(latestSub.value.toString()).toBe(String(MEMO_SEND_AMOUNT));
+
+      // The memo survives craft (.setTransactionMemo) and comes back via memo_base64 on the
+      // mirror transaction, landing in extra.
+      const { memo } = latestSub.extra as HederaOperationExtra;
+      expect(memo).toBe(MEMO);
+    },
+  };
+
+  const sendErc20Max: CanonicalHederaTransaction = {
+    name: `Send max ${TOKEN_SYMBOL} (ERC20)`,
+    mode: "send",
+    subAccountId: encodeTokenAccountId(makeHederaAccount(accountId, "").id, token),
+    // amount is what calculateAmount should arrive at; prepareTransaction overwrites it with the
+    // real sub-account balance.
+    amount: new BigNumber(SEND_MAX_AMOUNT),
+    useAllAmount: true,
+    recipient: recipientId,
+    expect: (previous, current) => {
+      const currentSub = findErc20SubAccount(current);
+      expect(currentSub).toBeDefined();
+      if (!currentSub) return;
+      expect(currentSub.balance.toString()).toBe("0");
+
+      const [latestSub] = currentSub.operations;
+      expect(latestSub).toBeDefined();
+      if (!latestSub) return;
+      expect(latestSub.type).toBe("OUT");
+      expect(latestSub.value.toString()).toBe(String(SEND_MAX_AMOUNT));
+    },
+  };
+
+  return [sendErc20, sendErc20WithMemo, sendErc20Max];
+}
+
+export function makeScenarioHederaErc20<T extends TransactionCommon>(
+  target: HederaBridgeTarget<T>,
+): Scenario<T, HederaAccount> {
+  return {
+    name: "Ledger Live Hedera — ERC20 transfer",
+
+    setup: async () => {
+      resetErc20Tokens();
+
+      // The token must be registered right after deploy: the hgraph-fake registry reset isn't wired
+      // into initMswHandlers.
+      const { contractId, evmAddress: deployedEvmAddress } = await deployErc20Token();
+      evmAddress = deployedEvmAddress;
+      registerErc20Token(contractId, evmAddress);
+
+      token = makeLocalErc20Token(evmAddress);
+
+      const {
+        currencyBridge,
+        accountBridge,
+        publicKey,
+        accountId: newAccountId,
+        close,
+      } = await target.setup([token]);
+      closeMswHandlers = close;
+      accountId = newAccountId;
+
+      const accountEvmAddress = await waitForMirrorNodeEvmAddress(accountId);
+
+      // Fund the account under test directly from the genesis operator, bypassing the bridge.
+      await transferErc20(evmAddress, accountEvmAddress, SEED_AMOUNT);
+
+      // The seed must be confirmed as a balance, not a transfer: the transfer feed is derived from
+      // the balance map and stays empty until a balance row exists.
+      await waitForErc20Balance(evmAddress, accountEvmAddress, SEED_AMOUNT);
+
+      // The recipient must be a freshly created funded account, not the RECIPIENT constant: the
+      // ERC20 path calls toEVMAddress on the recipient under an invariant, and only
+      // createFundedAccount guarantees the mirror node has evm_address populated for it.
+      recipientId = await createFundedAccount(
+        PrivateKey.generateED25519().publicKey.toStringRaw(),
+        1,
+      );
+
+      return {
+        currencyBridge,
+        accountBridge,
+        account: makeHederaAccount(accountId, publicKey),
+        ...SCENARIO_RETRY_POLICY,
+      };
+    },
+
+    beforeSync: async () => {
+      await refresh();
+    },
+
+    getTransactions: () => makeTransactions().map(target.toTransaction),
+
+    teardown: () => {
+      closeMswHandlers?.();
+      resetErc20Tokens();
+    },
+  };
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/scenarii/hederaErc20Receive.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/scenarii/hederaErc20Receive.ts
@@ -1,0 +1,110 @@
+import type { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
+import type { HederaAccount } from "@ledgerhq/coin-hedera/types";
+import type { TokenAccount, TransactionCommon } from "@ledgerhq/types-live";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import { TOKEN_SYMBOL, TOKEN_UNIT, makeHederaAccount, makeLocalErc20Token } from "../fixtures";
+import { SCENARIO_RETRY_POLICY, findTokenSubAccount } from "../helpers";
+import type { HederaBridgeTarget } from "../bridgeTarget";
+import {
+  deployErc20Token,
+  transferErc20,
+  waitForErc20Balance,
+  waitForMirrorNodeEvmAddress,
+} from "../genesis";
+import { registerErc20Token, resetErc20Tokens, refresh } from "../hgraphFake";
+
+const RECEIVE_AMOUNT = 42 * TOKEN_UNIT;
+
+let closeMswHandlers: (() => void) | undefined;
+let token: TokenCurrency;
+let tokenEvmAddress: string;
+let accountEvmAddress: string;
+let scenarioStartedAt: Date;
+
+function findErc20SubAccount(account: HederaAccount): TokenAccount | undefined {
+  return findTokenSubAccount(account, token.id);
+}
+
+export function makeScenarioHederaErc20Receive<T extends TransactionCommon>(
+  target: HederaBridgeTarget<T>,
+): Scenario<T, HederaAccount> {
+  return {
+    name: "Ledger Live Hedera — ERC20 received from a 3rd party",
+
+    setup: async () => {
+      resetErc20Tokens();
+      scenarioStartedAt = new Date();
+
+      const { contractId, evmAddress } = await deployErc20Token();
+      tokenEvmAddress = evmAddress;
+      registerErc20Token(contractId, evmAddress);
+
+      token = makeLocalErc20Token(evmAddress);
+
+      // No seeding: the whole point is that the account starts with a zero balance for this token.
+      const { currencyBridge, accountBridge, publicKey, accountId, close } =
+        await target.setup([token]);
+      closeMswHandlers = close;
+
+      accountEvmAddress = await waitForMirrorNodeEvmAddress(accountId);
+
+      // refresh() must run once here, or getErcTokenTransferRows throws on a null snapshot. After
+      // this the feed stays frozen and empty for our account, which is what this scenario tests.
+      await refresh();
+
+      return {
+        currencyBridge,
+        accountBridge,
+        account: makeHederaAccount(accountId, publicKey),
+        // retryLimit must stay well under MAX_TRANSFER_PAGES: transferPageCount only resets on a
+        // successful refresh(), and each sync issues one page request.
+        ...SCENARIO_RETRY_POLICY,
+      };
+    },
+
+    // No beforeSync here: refreshing after setup would populate the transfer feed that this
+    // scenario needs to stay empty.
+
+    beforeAll: account => {
+      expect(
+        account.subAccounts?.some(sa => sa.type === "TokenAccount" && sa.token.id === token.id),
+      ).toBe(false);
+    },
+
+    getTransactions: () => [],
+
+    getInternalTransactions: async (): Promise<ScenarioTransaction<T, HederaAccount>[]> => {
+      // Awaited by the runner before the (empty) regular-transaction loop. No refresh() follows,
+      // so the balance moves live while the transfer feed stays empty.
+      await transferErc20(tokenEvmAddress, accountEvmAddress, RECEIVE_AMOUNT);
+      await waitForErc20Balance(tokenEvmAddress, accountEvmAddress, RECEIVE_AMOUNT);
+
+      // Carries only `name`/`expect`: this internal transaction never reaches `prepareTransaction`,
+      // so it needs none of `T`'s own fields — hence the cast to the still-open generic `T`.
+      const receiveErc20 = {
+        name: `Receive ${RECEIVE_AMOUNT / TOKEN_UNIT} ${TOKEN_SYMBOL} (ERC20) from a 3rd party`,
+        expect: (previous, current) => {
+          const sub = findErc20SubAccount(current);
+          expect(sub).toBeDefined();
+          if (!sub) return; // retryable: mirror-node lag, not a TypeError
+
+          expect(sub.balance.toString()).toBe(String(RECEIVE_AMOUNT));
+          // The branch under test builds the sub-account from balance alone, so it carries no
+          // operations.
+          expect(sub.operations).toHaveLength(0);
+          expect(sub.operationsCount).toBe(0);
+          // creationDate is `new Date()` on this branch, so only the scenario window can be
+          // asserted.
+          expect(sub.creationDate.getTime()).toBeGreaterThanOrEqual(scenarioStartedAt.getTime());
+        },
+      } as ScenarioTransaction<T, HederaAccount>;
+
+      return [receiveErc20];
+    },
+
+    teardown: () => {
+      closeMswHandlers?.();
+      resetErc20Tokens();
+    },
+  };
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/scenarii/hederaMultiToken.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/scenarii/hederaMultiToken.ts
@@ -1,0 +1,125 @@
+import type { Scenario } from "@ledgerhq/coin-tester/main";
+import type { TransactionCommon } from "@ledgerhq/types-live";
+import type { HederaAccount } from "@ledgerhq/coin-hedera/types";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import BigNumber from "bignumber.js";
+import {
+  MAX_AUTO_ASSOCIATIONS,
+  ONE_HBAR_IN_TINYBAR,
+  RECIPIENT,
+  TOKEN_DECIMALS,
+  TOKEN_UNIT,
+  makeHederaAccount,
+  makeLocalHtsToken,
+} from "../fixtures";
+import { SCENARIO_RETRY_POLICY, findTokenSubAccount } from "../helpers";
+import type { HederaBridgeTarget } from "../bridgeTarget";
+import type { CanonicalHederaTransaction } from "../canonicalTransaction";
+import { createHtsToken, transferToken, waitForMirrorNodeTokenBalance } from "../genesis";
+
+const TOKEN_INITIAL_SUPPLY = 1_000 * TOKEN_UNIT;
+const TOKEN2_INJECTED = 50 * TOKEN_UNIT;
+const TOKEN3_INJECTED = 70 * TOKEN_UNIT;
+// Fixed partial send, not `useAllAmount`: a send-max here would fail on-chain since the account's
+// real spendable balance runs a touch below what the post-send sync reports.
+const HBAR_SENT = 50 * ONE_HBAR_IN_TINYBAR;
+
+let closeMswHandlers: (() => void) | undefined;
+let token2: TokenCurrency;
+let token3: TokenCurrency;
+let accountId: string;
+
+function makeTransactions(): CanonicalHederaTransaction[] {
+  const assertTokensPresent: CanonicalHederaTransaction = {
+    name: "Both LLT2 and LLT3 sub-accounts resolve with their injected balances",
+    mode: "send",
+    amount: new BigNumber(ONE_HBAR_IN_TINYBAR),
+    recipient: RECIPIENT,
+    expect: (previous, current) => {
+      const sub2 = findTokenSubAccount(current, token2.id);
+      const sub3 = findTokenSubAccount(current, token3.id);
+      expect(sub2).toBeDefined();
+      expect(sub3).toBeDefined();
+      if (!sub2 || !sub3) return; // retryable: mirror-node lag, not a TypeError
+      expect(sub2.balance.toString()).toBe(String(TOKEN2_INJECTED));
+      expect(sub3.balance.toString()).toBe(String(TOKEN3_INJECTED));
+    },
+  };
+
+  const sendHbarPreservingTokens: CanonicalHederaTransaction = {
+    name: "Send HBAR preserves both token sub-accounts",
+    mode: "send",
+    amount: new BigNumber(HBAR_SENT),
+    recipient: RECIPIENT,
+    expect: (previous, current) => {
+      expect(current.operations.length).toBeGreaterThan(previous.operations.length);
+      const [latest] = current.operations;
+      expect(latest.type).toBe("OUT");
+      expect(latest.recipients).toContain(RECIPIENT);
+      // Asserted off the operation, not a previous/current delta: `previous` can lag the real
+      // balance right after a send.
+      expect(latest.value.minus(latest.fee).toString()).toBe(String(HBAR_SENT));
+      expect(findTokenSubAccount(current, token2.id)?.balance.toString()).toBe(
+        findTokenSubAccount(previous, token2.id)?.balance.toString(),
+      );
+      expect(findTokenSubAccount(current, token3.id)?.balance.toString()).toBe(
+        findTokenSubAccount(previous, token3.id)?.balance.toString(),
+      );
+    },
+  };
+
+  return [assertTokensPresent, sendHbarPreservingTokens];
+}
+
+export function makeScenarioHederaMultiToken<T extends TransactionCommon>(
+  target: HederaBridgeTarget<T>,
+): Scenario<T, HederaAccount> {
+  return {
+    name: "Ledger Live Hedera — multiple HTS tokens via auto-association",
+
+    setup: async () => {
+      // Created first so both tokens are known when the crypto-assets store is installed.
+      const tokenId2 = await createHtsToken({
+        decimals: TOKEN_DECIMALS,
+        symbol: "LLT2",
+        initialSupply: TOKEN_INITIAL_SUPPLY,
+      });
+      const tokenId3 = await createHtsToken({
+        decimals: TOKEN_DECIMALS,
+        symbol: "LLT3",
+        initialSupply: TOKEN_INITIAL_SUPPLY,
+      });
+      token2 = makeLocalHtsToken(tokenId2);
+      token3 = makeLocalHtsToken(tokenId3);
+
+      const {
+        currencyBridge,
+        accountBridge,
+        publicKey,
+        accountId: newAccountId,
+        close,
+      } = await target.setup([token2, token3], MAX_AUTO_ASSOCIATIONS);
+      closeMswHandlers = close;
+      accountId = newAccountId;
+
+      // Auto-association means a treasury transfer associates on receipt; wait for indexing.
+      await transferToken(tokenId2, accountId, TOKEN2_INJECTED);
+      await transferToken(tokenId3, accountId, TOKEN3_INJECTED);
+      await waitForMirrorNodeTokenBalance(accountId, tokenId2, TOKEN2_INJECTED);
+      await waitForMirrorNodeTokenBalance(accountId, tokenId3, TOKEN3_INJECTED);
+
+      return {
+        currencyBridge,
+        accountBridge,
+        account: makeHederaAccount(accountId, publicKey),
+        ...SCENARIO_RETRY_POLICY,
+      };
+    },
+
+    getTransactions: () => makeTransactions().map(target.toTransaction),
+
+    teardown: () => {
+      closeMswHandlers?.();
+    },
+  };
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/scenarii/hederaStaking.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/scenarii/hederaStaking.ts
@@ -1,0 +1,81 @@
+import type { Scenario } from "@ledgerhq/coin-tester/main";
+import type { TransactionCommon } from "@ledgerhq/types-live";
+import type { HederaAccount } from "@ledgerhq/coin-hedera/types";
+import BigNumber from "bignumber.js";
+import { makeHederaAccount } from "../fixtures";
+import { SCENARIO_RETRY_POLICY } from "../helpers";
+import type { HederaBridgeTarget } from "../bridgeTarget";
+import type { CanonicalHederaTransaction } from "../canonicalTransaction";
+import { getFirstNodeId } from "../genesis";
+
+let closeMswHandlers: (() => void) | undefined;
+let accountId: string;
+let stakingNodeId: number;
+
+function makeTransactions(
+  getStakingNodeId: (account: HederaAccount) => number | null,
+): CanonicalHederaTransaction[] {
+  const delegate: CanonicalHederaTransaction = {
+    name: `Delegate to node ${stakingNodeId}`,
+    mode: "delegate",
+    stakingNodeId,
+    amount: new BigNumber(0),
+    recipient: accountId,
+    expect: (previous, current) => {
+      expect(current.operations.length).toBeGreaterThan(previous.operations.length);
+      const [latest] = current.operations;
+      expect(latest.type).toBe("DELEGATE");
+      expect(getStakingNodeId(current)).toBe(stakingNodeId);
+    },
+  };
+
+  const undelegate: CanonicalHederaTransaction = {
+    name: "Undelegate",
+    mode: "undelegate",
+    amount: new BigNumber(0),
+    recipient: accountId,
+    expect: (previous, current) => {
+      expect(current.operations.length).toBeGreaterThan(previous.operations.length);
+      const [latest] = current.operations;
+      expect(latest.type).toBe("UNDELEGATE");
+      // Non-vacuous only because `delegate` ran immediately before this in the scenario.
+      expect(getStakingNodeId(current)).toBeNull();
+    },
+  };
+
+  return [delegate, undelegate];
+}
+
+export function makeScenarioHederaStaking<T extends TransactionCommon>(
+  target: HederaBridgeTarget<T>,
+): Scenario<T, HederaAccount> {
+  return {
+    name: "Ledger Live Hedera — delegate and undelegate",
+
+    setup: async () => {
+      const {
+        currencyBridge,
+        accountBridge,
+        publicKey,
+        accountId: newAccountId,
+        close,
+      } = await target.setup([]);
+      closeMswHandlers = close;
+      accountId = newAccountId;
+      stakingNodeId = await getFirstNodeId();
+
+      return {
+        currencyBridge,
+        accountBridge,
+        account: makeHederaAccount(accountId, publicKey),
+        ...SCENARIO_RETRY_POLICY,
+      };
+    },
+
+    getTransactions: () => makeTransactions(target.getStakingNodeId).map(target.toTransaction),
+
+    teardown: () => {
+      closeMswHandlers?.();
+    },
+  };
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/scenarii/hederaToken.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/scenarii/hederaToken.ts
@@ -1,0 +1,175 @@
+import { PrivateKey } from "@hashgraph/sdk";
+import type { Scenario } from "@ledgerhq/coin-tester/main";
+import type { TokenAccount, TransactionCommon } from "@ledgerhq/types-live";
+import type { HederaAccount } from "@ledgerhq/coin-hedera/types";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import { encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account";
+import BigNumber from "bignumber.js";
+import {
+  TOKEN_DECIMALS,
+  TOKEN_SYMBOL,
+  TOKEN_UNIT,
+  makeHederaAccount,
+  makeLocalHtsToken,
+} from "../fixtures";
+import { SCENARIO_RETRY_POLICY, findTokenSubAccount } from "../helpers";
+import type { HederaBridgeTarget } from "../bridgeTarget";
+import type { CanonicalHederaTransaction } from "../canonicalTransaction";
+import {
+  associateToken,
+  createFundedAccount,
+  createHtsToken,
+  transferToken,
+  waitForMirrorNodeTokenBalance,
+} from "../genesis";
+
+const TOKEN_INITIAL_SUPPLY = 1_000 * TOKEN_UNIT;
+const TOKEN_INJECTED = 100 * TOKEN_UNIT;
+const TOKEN_SENT = 10 * TOKEN_UNIT;
+
+let closeMswHandlers: (() => void) | undefined;
+let token: TokenCurrency;
+let tokenId: string;
+let accountId: string;
+let tokenRecipientId: string;
+let injected = false;
+let beforeEachCallIndex = 0;
+
+function findSubAccount(account: HederaAccount): TokenAccount | undefined {
+  return findTokenSubAccount(account, token.id);
+}
+
+function makeTransactions(): CanonicalHederaTransaction[] {
+  const associate: CanonicalHederaTransaction = {
+    name: `Associate ${TOKEN_SYMBOL}`,
+    mode: "tokenAssociate",
+    assetReference: tokenId,
+    assetOwner: accountId,
+    token,
+    amount: new BigNumber(0),
+    recipient: accountId,
+    expect: (previous, current) => {
+      expect(current.operations.length).toBeGreaterThan(previous.operations.length);
+      // An associated HTS token with no operations and a zero balance still yields a sub-account.
+      const subAccount = findSubAccount(current);
+      expect(subAccount).toBeDefined();
+      if (!subAccount) return;
+      expect(subAccount.balance.toString()).toBe("0");
+    },
+  };
+
+  const sendToken: CanonicalHederaTransaction = {
+    name: `Send ${TOKEN_SENT / TOKEN_UNIT} ${TOKEN_SYMBOL} to a freshly associated account`,
+    mode: "send",
+    subAccountId: encodeTokenAccountId(makeHederaAccount(accountId, "").id, token),
+    amount: new BigNumber(TOKEN_SENT),
+    recipient: tokenRecipientId,
+    expect: (previous, current) => {
+      const previousSub = findSubAccount(previous);
+      const currentSub = findSubAccount(current);
+      expect(previousSub).toBeDefined();
+      expect(currentSub).toBeDefined();
+      if (!previousSub || !currentSub) return;
+      expect(currentSub.operations.length).toBeGreaterThan(0);
+      expect(currentSub.balance.toString()).toBe(previousSub.balance.minus(TOKEN_SENT).toString());
+      const [latest] = currentSub.operations;
+      expect(latest.type).toBe("OUT");
+      expect(latest.value.toString()).toBe(String(TOKEN_SENT));
+    },
+  };
+
+  const sendMaxLlt: CanonicalHederaTransaction = {
+    name: `Send max ${TOKEN_SYMBOL} (drains the sub-account)`,
+    mode: "send",
+    subAccountId: encodeTokenAccountId(makeHederaAccount(accountId, "").id, token),
+    useAllAmount: true,
+    recipient: tokenRecipientId,
+    expect: (previous, current) => {
+      const previousSub = findSubAccount(previous);
+      const currentSub = findSubAccount(current);
+      expect(previousSub).toBeDefined();
+      expect(currentSub).toBeDefined();
+      if (!previousSub || !currentSub) return; // retryable mirror-node lag, not a TypeError
+      expect(currentSub.operations.length).toBeGreaterThan(previousSub.operations.length);
+      const [latest] = currentSub.operations;
+      expect(latest.type).toBe("OUT");
+      expect(latest.value.toString()).toBe(previousSub.balance.toString());
+      expect(currentSub.balance.toString()).toBe("0");
+    },
+  };
+
+  return [associate, sendToken, sendMaxLlt];
+}
+
+export function makeScenarioHederaToken<T extends TransactionCommon>(
+  target: HederaBridgeTarget<T>,
+): Scenario<T, HederaAccount> {
+  return {
+    name: "Ledger Live Hedera — HTS association and transfer",
+
+    setup: async () => {
+      // Created before `setup` so the token is known when the crypto-assets store is installed.
+      tokenId = await createHtsToken({
+        decimals: TOKEN_DECIMALS,
+        symbol: TOKEN_SYMBOL,
+        initialSupply: TOKEN_INITIAL_SUPPLY,
+      });
+      token = makeLocalHtsToken(tokenId);
+
+      const {
+        currencyBridge,
+        accountBridge,
+        publicKey,
+        accountId: newAccountId,
+        close,
+      } = await target.setup([token]);
+      closeMswHandlers = close;
+      accountId = newAccountId;
+
+      // Separate fixture account, associated via the raw SDK: RECIPIENT's key isn't ours, so it
+      // can't be associated and an HTS transfer to it would fail.
+      const recipientKey = PrivateKey.generateED25519();
+      tokenRecipientId = await createFundedAccount(recipientKey.publicKey.toStringRaw(), 1);
+      await associateToken(tokenRecipientId, recipientKey, tokenId);
+
+      injected = false;
+      beforeEachCallIndex = 0;
+
+      return {
+        currencyBridge,
+        accountBridge,
+        account: makeHederaAccount(accountId, publicKey),
+        ...SCENARIO_RETRY_POLICY,
+      };
+    },
+
+    // HTS requires the receiver to be associated first, so the treasury injection has to sit between
+    // `associate` and `sendToken` — hence the call-position key. Reordering them stops it firing.
+    beforeEach: async account => {
+      const callIndex = beforeEachCallIndex++;
+      if (callIndex === 0) return; // precedes `associate`: the sub-account cannot exist yet.
+      if (injected) return;
+
+      const subAccount = findSubAccount(account);
+      if (!subAccount) {
+        throw new Error(
+          `hederaToken scenario: expected the ${TOKEN_SYMBOL} sub-account to exist before injecting ` +
+            `the treasury transfer (beforeEach call #${callIndex + 1}, following the "associate" ` +
+            "transaction), but found none. The transaction order likely changed, or sub-account " +
+            "resolution regressed.",
+        );
+      }
+
+      await transferToken(tokenId, account.freshAddress, TOKEN_INJECTED);
+      // getTransactionStatus right after is not retried: without this, the sub-account reads 0.
+      await waitForMirrorNodeTokenBalance(account.freshAddress, tokenId, TOKEN_INJECTED);
+      injected = true;
+    },
+
+    getTransactions: () => makeTransactions().map(target.toTransaction),
+
+    teardown: () => {
+      closeMswHandlers?.();
+    },
+  };
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/signer.test.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/signer.test.ts
@@ -1,0 +1,43 @@
+import { PrivateKey, PublicKey } from "@hashgraph/sdk";
+import { buildHederaSigner } from "./signer";
+
+describe("buildHederaSigner", () => {
+  it("returns a 64-hex-char raw Ed25519 public key (never DER)", async () => {
+    const signer = buildHederaSigner();
+
+    const publicKey = await signer.getPublicKey("44/3030");
+
+    expect(publicKey).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("returns the same public key on every call (fixed key)", async () => {
+    const signer = buildHederaSigner();
+
+    const first = await signer.getPublicKey("44/3030");
+    const second = await signer.getPublicKey("44/3030");
+
+    expect(first).toBe(second);
+  });
+
+  it("signs the exact body bytes handed to it, with no prefix or re-encoding", async () => {
+    const signer = buildHederaSigner();
+    const publicKeyHex = await signer.getPublicKey("44/3030");
+    const bodyBytes = new Uint8Array([1, 2, 3, 4, 5]);
+
+    const signature = await signer.signTransaction(bodyBytes);
+
+    const verified = PublicKey.fromString(publicKeyHex).verify(bodyBytes, signature);
+
+    expect(verified).toBe(true);
+  });
+});
+
+describe("buildHederaSigner key isolation", () => {
+  it("uses an explicitly supplied key, so fixtures can co-sign for the same account", async () => {
+    const key = PrivateKey.generateED25519();
+
+    const publicKey = await buildHederaSigner(key).getPublicKey("44/3030");
+
+    expect(publicKey).toBe(key.publicKey.toStringRaw());
+  });
+});

--- a/libs/coin-tester-modules/coin-tester-hedera/src/signer.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/signer.ts
@@ -1,0 +1,26 @@
+import { PrivateKey } from "@hashgraph/sdk";
+import type { HederaSigner } from "@ledgerhq/coin-hedera/types";
+
+/**
+ * One signer per account under test; an explicit key lets fixture code sign for the same account
+ * with the raw SDK. `getPublicKey` must return the raw 32-byte Ed25519 hex, not DER — it becomes
+ * `seedIdentifier`, which `combine()` feeds into `PublicKey.fromString`.
+ */
+export function buildHederaSigner(
+  privateKey: PrivateKey = PrivateKey.generateED25519(),
+): HederaSigner {
+  return {
+    async getPublicKey(_path: string): Promise<string> {
+      const raw = privateKey.publicKey.toStringRaw();
+      if (raw.length !== 64) {
+        throw new Error(
+          `hedera tester signer: expected a 64-char raw Ed25519 public key, got ${raw.length} chars — the SDK may have changed its default encoding to DER`,
+        );
+      }
+      return raw;
+    },
+    async signTransaction(transaction: Uint8Array): Promise<Uint8Array> {
+      return privateKey.sign(transaction);
+    },
+  };
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/src/solo.test.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/solo.test.ts
@@ -1,0 +1,96 @@
+const execFileMock = jest.fn();
+
+jest.mock("child_process", () => ({
+  execFile: (
+    file: string,
+    args: string[],
+    opts: unknown,
+    cb: (err: Error | null, res: { stdout: string; stderr: string }) => void,
+  ) => {
+    execFileMock(file, args);
+    cb(null, { stdout: "", stderr: "" });
+  },
+}));
+
+const rmMock = jest.fn();
+
+jest.mock("fs/promises", () => ({
+  ...jest.requireActual("fs/promises"),
+  rm: (...args: unknown[]) => rmMock(...args),
+}));
+
+import { deploySolo, teardownSolo } from "./solo";
+
+const deployCalls = () => execFileMock.mock.calls.filter(([, args]) => args[2] === "deploy");
+
+describe("deploySolo memoisation", () => {
+  beforeEach(() => {
+    execFileMock.mockClear();
+    execFileMock.mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    await teardownSolo();
+  });
+
+  it("shells out to `solo one-shot falcon deploy` exactly once for repeated calls", async () => {
+    await deploySolo();
+    await deploySolo();
+    await deploySolo();
+
+    expect(deployCalls()).toHaveLength(1);
+    expect(deployCalls()[0][1]).toEqual([
+      "one-shot",
+      "falcon",
+      "deploy",
+      "--deployment",
+      "coin-tester-hedera",
+      "--namespace",
+      "coin-tester-hedera",
+      "--no-deploy-relay",
+      "--no-deploy-explorer",
+      "--quiet-mode",
+    ]);
+  });
+
+  it("deploys again after teardown, so a second suite run is not silently a no-op", async () => {
+    await deploySolo();
+    await teardownSolo();
+    await deploySolo();
+
+    expect(deployCalls()).toHaveLength(2);
+  });
+
+  it("caches a failed deploy, so an environment failure does not trigger a second 10-minute attempt", async () => {
+    execFileMock.mockImplementation((_file: string, args: string[]) => {
+      if (args[2] === "deploy") throw new Error("cluster bring-up failed");
+    });
+
+    await expect(deploySolo()).rejects.toThrow("cluster bring-up failed");
+    await expect(deploySolo()).rejects.toThrow("cluster bring-up failed");
+
+    expect(deployCalls()).toHaveLength(1);
+  });
+
+  it("tears down via `solo one-shot falcon destroy`", async () => {
+    await deploySolo();
+    execFileMock.mockClear();
+    rmMock.mockClear();
+    await teardownSolo();
+
+    const destroyCalls = execFileMock.mock.calls.filter(([, args]) => args[2] === "destroy");
+    expect(destroyCalls).toHaveLength(1);
+    expect(destroyCalls[0][1]).toEqual([
+      "one-shot",
+      "falcon",
+      "destroy",
+      "--deployment",
+      "coin-tester-hedera",
+      "--quiet-mode",
+    ]);
+    expect(rmMock).toHaveBeenCalledWith(
+      expect.stringContaining("one-shot-coin-tester-hedera"),
+      expect.objectContaining({ recursive: true, force: true }),
+    );
+  });
+});

--- a/libs/coin-tester-modules/coin-tester-hedera/src/solo.ts
+++ b/libs/coin-tester-modules/coin-tester-hedera/src/solo.ts
@@ -1,0 +1,161 @@
+import { execFile } from "child_process";
+import { rm } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+import { promisify } from "util";
+import chalk from "chalk";
+
+const execFileAsync = promisify(execFile);
+
+const EXEC_OPTS = { env: process.env, maxBuffer: 1024 * 1024 * 64 } as const;
+
+const SOLO_BIN = "solo"; // resolved from the package's own node_modules/.bin via pnpm
+
+/** Dedicated deployment + namespace, kept separate from Solo's default `one-shot` name. */
+const DEPLOYMENT_NAME = "coin-tester-hedera";
+
+/**
+ * Memoised deployment: the *promise* is stored (not the resolved value) so concurrent callers
+ * can't start two deploys. A failed bring-up is cached too — a kube/Solo failure is an
+ * environment fault, so every caller should fail immediately rather than retry for ~10 min.
+ */
+let deployment: Promise<void> | undefined;
+
+/** `solo one-shot falcon deploy` writes account material to `<SOLO_HOME>/one-shot-<deployment>/accounts.json`. */
+const oneShotOutputDir = () =>
+  join(process.env.SOLO_HOME ?? join(homedir(), ".solo"), `one-shot-${DEPLOYMENT_NAME}`);
+
+export function deploySolo(): Promise<void> {
+  deployment ??= runDeploy();
+  return deployment;
+}
+
+async function runDeploy(): Promise<void> {
+  console.log("Deploying Hiero Solo (one-shot falcon, single node)…");
+
+  // `--no-deploy-relay`/`--no-deploy-explorer` skip the JSON-RPC relay and explorer pods — the
+  // tester only ever talks to the consensus node and mirror node REST API.
+  //
+  // A hard-killed run bypasses `teardownSolo` and leaves state a later `deploy --quiet-mode`
+  // rejects — recover with `solo one-shot falcon destroy --deployment coin-tester-hedera`.
+  await execFileAsync(
+    SOLO_BIN,
+    [
+      "one-shot",
+      "falcon",
+      "deploy",
+      "--deployment",
+      DEPLOYMENT_NAME,
+      "--namespace",
+      DEPLOYMENT_NAME,
+      "--no-deploy-relay",
+      "--no-deploy-explorer",
+      "--quiet-mode",
+    ],
+    EXEC_OPTS,
+  );
+
+  console.log(chalk.bgBlueBright(" -  SOLO READY ✅  - "));
+}
+
+export async function teardownSolo(): Promise<void> {
+  deployment = undefined;
+  console.log("Tearing down Hiero Solo…");
+  await destroyQuietly();
+  await removeOneShotOutputDirQuietly();
+  await killPortForwards();
+}
+
+/** Best-effort: must never throw during teardown, or it would mask the real test outcome. */
+async function destroyQuietly(): Promise<void> {
+  try {
+    await execFileAsync(
+      SOLO_BIN,
+      ["one-shot", "falcon", "destroy", "--deployment", DEPLOYMENT_NAME, "--quiet-mode"],
+      EXEC_OPTS,
+    );
+  } catch (err) {
+    console.error("solo.ts: `one-shot falcon destroy` failed (ignored):", err);
+  }
+}
+
+/**
+ * `destroy` skips removing the output dir when Solo's local config lists no deployment — the state
+ * a hard-killed run leaves behind. Remove it ourselves: Solo rewrites it on every deploy.
+ * Best-effort like the rest of teardown: `force` swallows ENOENT but not EACCES/EBUSY.
+ */
+async function removeOneShotOutputDirQuietly(): Promise<void> {
+  try {
+    await rm(oneShotOutputDir(), { recursive: true, force: true });
+  } catch (err) {
+    console.error("solo.ts: could not remove the one-shot output dir (ignored):", err);
+  }
+}
+
+/** Solo's tunnels are spawned `detached` and outlive `destroy`, holding 35211/38081. Never throws. */
+async function killPortForwards(): Promise<void> {
+  if (process.platform === "win32") {
+    console.warn(
+      "solo.ts: no port-forward cleanup on Windows — if the next run cannot bind 35211/38081, " +
+        "kill the leftover `kubectl port-forward` processes by hand.",
+    );
+    return;
+  }
+
+  // Order matters: `persist-port-forward` respawns a dropped tunnel, so its kubectl child must
+  // not be killed first.
+  const patterns = [
+    `persist-port-forward.* ${DEPLOYMENT_NAME} `,
+    `port-forward .*${DEPLOYMENT_NAME}`,
+  ];
+
+  for (const pattern of patterns) {
+    await killMatching(pattern, "SIGTERM");
+  }
+  // `persist-port-forward` exits ~500 ms after SIGTERM (it lets its child wind down first).
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  for (const pattern of patterns) {
+    await killMatching(pattern, "SIGKILL");
+  }
+}
+
+async function killMatching(pattern: string, signal: "SIGTERM" | "SIGKILL"): Promise<void> {
+  let pids: number[];
+  try {
+    const { stdout } = await execFileAsync("pgrep", ["-f", pattern], EXEC_OPTS);
+    pids = stdout.split("\n").map(Number).filter(Boolean);
+  } catch {
+    // pgrep exits 1 when nothing matched — the common, healthy case.
+    return;
+  }
+
+  // `-f` matches whole command lines, so a shell merely mentioning the pattern matches too.
+  // Never signal our own tree.
+  const ownTree = await ancestorPids();
+
+  for (const pid of pids) {
+    if (ownTree.has(pid)) continue;
+    try {
+      process.kill(pid, signal);
+      console.log(`solo.ts: sent ${signal} to leftover port-forward process ${pid}`);
+    } catch {
+      // Already exited between pgrep and kill, or not ours to kill.
+    }
+  }
+}
+
+/** Our own pid plus every parent up to init. */
+async function ancestorPids(): Promise<Set<number>> {
+  const pids = new Set<number>();
+  let pid = process.pid;
+  while (pid > 1 && !pids.has(pid)) {
+    pids.add(pid);
+    try {
+      const { stdout } = await execFileAsync("ps", ["-o", "ppid=", "-p", String(pid)], EXEC_OPTS);
+      pid = Number(stdout.trim());
+    } catch {
+      break;
+    }
+  }
+  return pids;
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/tsconfig.build.json
+++ b/libs/coin-tester-modules/coin-tester-hedera/tsconfig.build.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "customConditions": [],
+    "types": ["node", "jest"]
+  },
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**/*",
+    "**/tests/**/*",
+    "**/__mocks__/**/*",
+    "**/*.test.js",
+    "**/*.test.jsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx"
+  ]
+}

--- a/libs/coin-tester-modules/coin-tester-hedera/tsconfig.json
+++ b/libs/coin-tester-modules/coin-tester-hedera/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base",
+  "compilerOptions": {
+    "lib": ["es2020", "dom"],
+    "outDir": "lib",
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*", "src/**/*.json"]
+}

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "coin:tester:cardano": "pnpm --filter coin-tester-cardano",
     "coin:tester:cosmos": "pnpm --filter coin-tester-cosmos",
     "coin:tester:evm": "pnpm --filter coin-tester-evm",
+    "coin:tester:hedera": "pnpm --filter coin-tester-hedera",
     "coin:tester:polkadot": "pnpm --filter coin-tester-polkadot",
     "coin:tester:solana": "pnpm --filter coin-tester-solana",
     "coin:tester:bitcoin": "pnpm --filter coin-tester-bitcoin",
@@ -317,6 +318,12 @@
       "@hiero-ledger/proto@2.25.0": "patches/@hiero-ledger__proto@2.25.0.patch"
     },
     "packageExtensions": {
+      "@hiero-ledger/solo": {
+        "dependencies": {
+          "reflect-metadata": "^0.2.2",
+          "protobufjs": "^8.0.1"
+        }
+      },
       "detox-allure2-adapter": {
         "dependencies": {
           "tslib": "*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,7 +534,7 @@ overrides:
   '@ledgerhq/device-signer-kit-aleo>@ledgerhq/signer-utils': 1.1.3
   '@ton/ton>zod': 4.3.6
 
-packageExtensionsChecksum: sha256-ncotzmACiC2rOyyMil4Rrs2djdIDzC2+p16TbkRXDRA=
+packageExtensionsChecksum: sha256-rZP6+BCGd6/5mhi73eHxlz968ntsQT2ytsUY8eapgCQ=
 
 pnpmfileChecksum: sha256-xLqSS12ZnNWPulG7lBzO/RFXZkVYpafIseIHU3FfiO4=
 
@@ -8696,6 +8696,76 @@ importers:
         specifier: 'catalog:'
         version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
+      '@ledgerhq/wallet-framework-test-setup':
+        specifier: workspace:^
+        version: link:../../wallet-framework-test-setup
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.36.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.51.0
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
+  libs/coin-tester-modules/coin-tester-hedera:
+    dependencies:
+      '@hashgraph/sdk':
+        specifier: 2.78.0
+        version: 2.78.0
+      '@ledgerhq/coin-hedera':
+        specifier: workspace:^
+        version: link:../../coin-modules/coin-hedera
+      '@ledgerhq/coin-tester':
+        specifier: workspace:^
+        version: link:../../coin-tester
+      '@ledgerhq/ledger-wallet-framework':
+        specifier: workspace:^
+        version: link:../../ledger-wallet-framework
+      '@ledgerhq/live-common':
+        specifier: workspace:^
+        version: link:../../ledger-live-common
+      '@ledgerhq/live-config':
+        specifier: workspace:^
+        version: link:../../live-config
+      '@ledgerhq/types-live':
+        specifier: workspace:^
+        version: link:../../types-live
+      bignumber.js:
+        specifier: 9.1.2
+        version: 9.1.2
+      chalk:
+        specifier: ^4.1.2
+        version: 4.1.2
+      msw:
+        specifier: 'catalog:'
+        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+      viem:
+        specifier: ^2.27.0
+        version: 2.37.4(@typescript/typescript6@6.0.2)
+    devDependencies:
+      '@hiero-ledger/solo':
+        specifier: 0.83.0
+        version: 0.83.0(@types/node@24.12.0)
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
         version: link:../../wallet-framework-test-setup
@@ -18884,6 +18954,10 @@ packages:
     resolution: {integrity: sha512-JXUj6PI0oqqzTGvKtzOkxtpsyPRNsrmhh41TtIz/zEB6J+AUiZZ0dxWzcMwO9Ns5rmSPuMdghlTbUuqIM48d3Q==}
     engines: {node: '>=12.10.0'}
 
+  '@grpc/grpc-js@1.12.7':
+    resolution: {integrity: sha512-Tugep4V4GCsN9dSAVkXoBWqJXDoH+NSXd50kFGsm7ZG1tBXFEAnLoxzkGUIksTrDjiaMwlpsbC24oWbESGHpIQ==}
+    engines: {node: '>=12.10.0'}
+
   '@grpc/grpc-js@1.13.4':
     resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
     engines: {node: '>=12.10.0'}
@@ -18943,6 +19017,15 @@ packages:
       expo-crypto:
         optional: true
 
+  '@hiero-ledger/cryptography@1.20.1':
+    resolution: {integrity: sha512-CGm49a84Z/Hext3UvsGP4jnUq/hoxIzdACbxgfEluhiZ43Z5PJAEh4h6Udsa+SRmMB8sdUbnRxiq67Sgj8FYbg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      expo-crypto: '*'
+    peerDependenciesMeta:
+      expo-crypto:
+        optional: true
+
   '@hiero-ledger/proto@2.25.0':
     resolution: {integrity: sha512-yZ9gb/2FMUSvH+txR1g1Z/03vbl4T11H8qw1NQyIuKhXe4PE8Ct8iHAL62aS0BN+OcR6CaF2wkfkQa16kgIkSA==}
     engines: {node: '>=10.0.0'}
@@ -18952,6 +19035,26 @@ packages:
       debug: 4.4.1
       protobufjs: 7.5.4
       strip-ansi: 7.1.2
+
+  '@hiero-ledger/proto@2.31.0':
+    resolution: {integrity: sha512-6Uq9cSK1lqhMsP/Zwz3liKIzn5QtN2dvt/7EET00/LdubYxYqVxREs8SCtYbgOlzMy34n1Hl6eNeEDDFpkQhMg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      ansi-regex: 6.2.2
+      ansi-styles: 6.2.3
+      debug: 4.4.1
+      protobufjs: 8.0.1
+      strip-ansi: 7.1.2
+
+  '@hiero-ledger/sdk@2.86.2':
+    resolution: {integrity: sha512-Mxhc+pxrsMe8+74Zij3Y/YPgBx7IDqHCq7BwLS26SDrez5DPnHw0Lyl+O6UsrHwjSbuV+qlXlhXwXQgBXxqlXQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@hiero-ledger/solo@0.83.0':
+    resolution: {integrity: sha512-QiyPgOJCrlsjLpTFm9Tk2ALcWznJCnYreMJthqiLG+Y1h0zxh9HsAA36rm+YMVWNCpXXcw89EreVSyinlbOwDQ==}
+    engines: {node: '>=22.0.0', npm: '>=9.8.1'}
+    os: [darwin, linux, win32]
+    hasBin: true
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -18965,6 +19068,28 @@ packages:
   '@humanwhocodes/object-schema@2.0.2':
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
     deprecated: Use @eslint/object-schema instead
+
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@inquirer/confirm@5.1.7':
     resolution: {integrity: sha512-Xrfbrw9eSiHb+GsesO8TQIeHSMTP0xyvTCeeYevgZ4sKW+iz9w/47bgfG9b0niQm+xaLY2EWPBINUPldLwvYiw==}
@@ -18984,13 +19109,134 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/figures@1.0.11':
     resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
     engines: {node: '>=18'}
 
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/type@3.0.5':
     resolution: {integrity: sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -19337,6 +19583,18 @@ packages:
     resolution: {integrity: sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==}
     engines: {node: '>=v12.0.0'}
 
+  '@jsep-plugin/assignment@1.3.0':
+    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@jsep-plugin/regex@1.0.4':
+    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
   '@jsonjoy.com/base64@1.1.2':
     resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
     engines: {node: '>=10.0'}
@@ -19460,9 +19718,15 @@ packages:
   '@keplr-wallet/proto-types@0.12.306':
     resolution: {integrity: sha512-vKCzgSmnNaUSRm4rAyxQGcf+oaNo/2l68zPNu3XxvqwnGCiHGbmRKc13hk7lBUrGyWnL5+J2NYmJy0E6iqS6xw==}
 
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
   '@koa/cors@3.4.3':
     resolution: {integrity: sha512-WPXQUaAeAMVaLTEFpoq3T2O1C+FstkjJnDQqy95Ck1UdILajsRhu6mhJ8H2f4NFPRBoCNN+qywTJfq/gGki5mw==}
     engines: {node: '>= 8.0.0'}
+
+  '@kubernetes/client-node@1.4.0':
+    resolution: {integrity: sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==}
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
@@ -19768,6 +20032,13 @@ packages:
   '@lezer/lr@1.4.1':
     resolution: {integrity: sha512-CHsKq8DMKBf9b3yXPDIU4DbH+ZJd/sJdYOW2llbW/HudP5u0VS6Bfq1hLYfgU7uAYGFIyGGQIsSOXGPEErZiJw==}
 
+  '@listr2/prompt-adapter-inquirer@4.2.4':
+    resolution: {integrity: sha512-/KRI2DMD7JGSYaREF0Ygl7AefJ/2ase4Gc5cBiKqT5l4tFjsSJfhFGcc5nSkgl0Sp9LkCQNzl/cqbVJYP2L3dw==}
+    engines: {node: '>=22.13.0'}
+    peerDependencies:
+      '@inquirer/prompts': '>= 3 < 9'
+      listr2: 10.2.1
+
   '@lottiefiles/dotlottie-react@0.17.13':
     resolution: {integrity: sha512-Ui8bqFlxqxLqB3G4bE9nsSw05lUn7eiZ24dSi/NVHFjTMAlb/JxdS8xWt1cdF2W1yJPNCeQuze6kkqNC5OMbJg==}
     peerDependencies:
@@ -19983,6 +20254,10 @@ packages:
 
   '@near-js/wallet-account@1.0.2':
     resolution: {integrity: sha512-bbouucpBgFtZ3bI7KvcYT8/r1q4w5UVIbbZqTUnuXpkceSQ7IxjeKCR00Iastj9EOXWAAAJBYkn0942QJjBC5w==}
+
+  '@noble/ciphers@1.2.1':
+    resolution: {integrity: sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
@@ -20821,6 +21096,47 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@peculiar/asn1-cms@2.8.0':
+    resolution: {integrity: sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==}
+
+  '@peculiar/asn1-csr@2.8.0':
+    resolution: {integrity: sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==}
+
+  '@peculiar/asn1-ecc@2.8.0':
+    resolution: {integrity: sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==}
+
+  '@peculiar/asn1-pfx@2.8.0':
+    resolution: {integrity: sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==}
+
+  '@peculiar/asn1-pkcs8@2.8.0':
+    resolution: {integrity: sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==}
+
+  '@peculiar/asn1-pkcs9@2.8.0':
+    resolution: {integrity: sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==}
+
+  '@peculiar/asn1-rsa@2.8.0':
+    resolution: {integrity: sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==}
+
+  '@peculiar/asn1-schema@2.8.0':
+    resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
+
+  '@peculiar/asn1-x509-attr@2.8.0':
+    resolution: {integrity: sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==}
+
+  '@peculiar/asn1-x509@2.8.0':
+    resolution: {integrity: sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==}
+
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+
+  '@peculiar/x509@1.14.3':
+    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@peculiar/x509@2.0.0':
+    resolution: {integrity: sha512-r10lkuy6BNfRmyYdRAfgu6dq0HOmyIV2OLhXWE3gDEPBdX1b8miztJVyX/UxWhLwemNyDP3CLZHpDxDwSY0xaA==}
+    engines: {node: '>=20.0.0'}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -22372,6 +22688,9 @@ packages:
   '@scure/base@1.1.6':
     resolution: {integrity: sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==}
 
+  '@scure/base@1.2.4':
+    resolution: {integrity: sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==}
+
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
@@ -22380,6 +22699,9 @@ packages:
 
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
+
+  '@scure/bip32@1.6.2':
+    resolution: {integrity: sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==}
 
   '@scure/bip32@1.7.0':
     resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
@@ -22492,6 +22814,12 @@ packages:
   '@sideway/pinpoint@2.0.0':
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
+  '@simple-git/args-pathspec@1.0.3':
+    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
+
+  '@simple-git/argv-parser@1.1.1':
+    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
+
   '@simple-libs/stream-utils@2.0.0':
     resolution: {integrity: sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==}
     engines: {node: '>=22'}
@@ -22508,6 +22836,10 @@ packages:
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
+
+  '@sindresorhus/is@8.1.0':
+    resolution: {integrity: sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==}
+    engines: {node: '>=22'}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -23842,7 +24174,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: '*'
+      webpack: ^5.89.0
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -24780,6 +25112,9 @@ packages:
   '@types/http-cache-semantics@4.0.4':
     resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
 
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
+
   '@types/http-errors@2.0.4':
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
 
@@ -24806,6 +25141,9 @@ packages:
 
   '@types/jest@30.0.0':
     resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/jsdom@21.1.7':
     resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
@@ -24875,6 +25213,9 @@ packages:
 
   '@types/node-fetch@2.6.11':
     resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
+
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
   '@types/node-forge@1.3.11':
     resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
@@ -25096,6 +25437,9 @@ packages:
   '@types/statuses@2.0.5':
     resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
 
+  '@types/stream-buffers@3.0.8':
+    resolution: {integrity: sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==}
+
   '@types/stream-chain@2.0.4':
     resolution: {integrity: sha512-V7TsWLHrx79KumkHqSD7F8eR6POpEuWb6PuXJ7s/dRHAf3uVst3Jkp1yZ5XqIfECZLQ4a28vBVstTErmsMBvaQ==}
 
@@ -25151,6 +25495,9 @@ packages:
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
+
+  '@types/validator@13.15.10':
+    resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
 
   '@types/verror@1.10.10':
     resolution: {integrity: sha512-l4MM0Jppn18hb9xmM6wwD1uTdShpf9Pn80aXTStnK1C94gtPvJcV2FrDmbOQUAQfJ1cKZHktkQUDwEqaAKXMMg==}
@@ -26002,6 +26349,10 @@ packages:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
 
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
+
   aes-js@3.1.2:
     resolution: {integrity: sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==}
 
@@ -26116,6 +26467,10 @@ packages:
     resolution: {integrity: sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==}
     engines: {node: '>=12'}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-fragments@0.2.1:
     resolution: {integrity: sha512-DykbNHxuXQwUDRv5ibc2b0x7uw7wmwOGLBUd5RmaQ5z8Lhx19vwvKV+FAsM5rEA6dEcHxX+/Ad5s9eF2k2bB+w==}
 
@@ -26171,7 +26526,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -26325,6 +26680,10 @@ packages:
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
+
   asn1js@3.0.6:
     resolution: {integrity: sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==}
     engines: {node: '>=12.0.0'}
@@ -26457,6 +26816,14 @@ packages:
 
   b4a@1.6.6:
     resolution: {integrity: sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -26634,6 +27001,43 @@ packages:
 
   bare-events@2.4.2:
     resolution: {integrity: sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==}
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.8.0:
+    resolution: {integrity: sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==}
+    engines: {bare: '>=1.28.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-path@3.1.1:
+    resolution: {integrity: sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.7:
+    resolution: {integrity: sha512-o8CRCiJtib+ycO3mE4A5UChtGX4dDP2XxsWVu9P+Zc3H8tcmKwNVEDoDTXmwN+uuMhfKeT7/i7Y26xS8W7ohoA==}
 
   base-64@0.1.0:
     resolution: {integrity: sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==}
@@ -26831,6 +27235,9 @@ packages:
 
   bn.js@5.2.2:
     resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
+
+  bn.js@5.2.3:
+    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
@@ -27079,6 +27486,10 @@ packages:
     engines: {'0': node >=0.10.0}
     hasBin: true
 
+  byte-counter@0.1.0:
+    resolution: {integrity: sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==}
+    engines: {node: '>=20'}
+
   byte-size@6.2.0:
     resolution: {integrity: sha512-6EspYUCAPMc7E2rltBgKwhG+Cmk0pDm9zDtF1Awe2dczNUL3YpZ8mTs/dueOTS1hqGWBOatqef4jYMGjln7WmA==}
     engines: {node: '>=8'}
@@ -27090,6 +27501,10 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  bytestreamjs@2.0.1:
+    resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
+    engines: {node: '>=6.0.0'}
 
   c32check@1.1.3:
     resolution: {integrity: sha512-ADADE/PjAbJRlwpG3ShaOMbBUlJJZO7xaYSRD5Tub6PixQlgR4s36y9cvMf/YRGpkqX+QOxIdMw216iC320q9A==}
@@ -27114,6 +27529,14 @@ packages:
   cacheable-lookup@5.0.4:
     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
     engines: {node: '>=10.6.0'}
+
+  cacheable-lookup@7.0.0:
+    resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
+    engines: {node: '>=14.16'}
+
+  cacheable-request@13.0.19:
+    resolution: {integrity: sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==}
+    engines: {node: '>=18'}
 
   cacheable-request@7.0.4:
     resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
@@ -27273,6 +27696,9 @@ packages:
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
+  chardet@2.2.0:
+    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
+
   charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
 
@@ -27326,6 +27752,10 @@ packages:
   chromium-pickle-js@0.2.0:
     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
 
+  chunk-data@0.1.0:
+    resolution: {integrity: sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==}
+    engines: {node: '>=20'}
+
   ci-info@2.0.0:
     resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
 
@@ -27342,6 +27772,12 @@ packages:
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
+  class-transformer@0.5.1:
+    resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
+
+  class-validator@0.15.1:
+    resolution: {integrity: sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -27368,6 +27804,10 @@ packages:
   cli-cursor@4.0.0:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
 
   cli-highlight@2.1.11:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
@@ -27398,6 +27838,10 @@ packages:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
 
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
+
   cli-width@2.2.1:
     resolution: {integrity: sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==}
 
@@ -27425,6 +27869,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
 
   clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
@@ -27582,6 +28030,10 @@ packages:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@2.13.0:
     resolution: {integrity: sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==}
 
@@ -27594,6 +28046,10 @@ packages:
 
   commander@5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
+    engines: {node: '>= 6'}
+
+  commander@6.2.1:
+    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
 
   commander@7.2.0:
@@ -28527,6 +28983,10 @@ packages:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
 
+  decompress-response@10.0.0:
+    resolution: {integrity: sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==}
+    engines: {node: '>=20'}
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -28846,6 +29306,10 @@ packages:
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
+  dot-object@2.1.5:
+    resolution: {integrity: sha512-xHF8EP4XH/Ba9fvAF2LDd5O3IITVolerVV6xvkxoM8zlGEiCUrggpAnHyOoKJKCrhvPcGATFAUwIujj7bRG5UA==}
+    hasBin: true
+
   dot-prop@10.1.0:
     resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
     engines: {node: '>=20'}
@@ -28875,6 +29339,10 @@ packages:
 
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dotenv@8.6.0:
@@ -29104,6 +29572,13 @@ packages:
     resolution: {integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==}
     engines: {node: '>=4'}
     hasBin: true
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
+  eol@0.10.0:
+    resolution: {integrity: sha512-+w3ktYrOphcIqC1XKmhQYvM+o2uxgQFiimL7B6JPZJlWVxf7Lno9e/JWLPIgbHo7DoZ+b7jsf/NzrUcNe6ZTZQ==}
 
   eol@0.9.1:
     resolution: {integrity: sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==}
@@ -29344,9 +29819,15 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   eventid@2.0.1:
     resolution: {integrity: sha512-sPNTqiMokAvV048P2c9+foqVJzk49o6d4e0D/sq5jog3pw+4kBgyR0gaM1FM7Mx6Kzd9dztesh9oYz1LWWOpzw==}
     engines: {node: '>=10'}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
   events@1.1.1:
     resolution: {integrity: sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==}
@@ -29733,6 +30214,9 @@ packages:
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
 
+  fast-copy@4.0.4:
+    resolution: {integrity: sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA==}
+
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
 
@@ -29855,6 +30339,11 @@ packages:
   fetch-cookie@3.2.0:
     resolution: {integrity: sha512-n61pQIxP25C6DRhcJxn7BDzgHP/+S56Urowb5WFxtcRMpU6drqXD90xjyAsVQYsNSNNVbaCcYY1DuHsdkZLuiA==}
 
+  figlet@1.11.1:
+    resolution: {integrity: sha512-piyV6z7Kg7N/VQnYjFcJylphkVxjXbCim1/mL3+cOnDoOTi0XP3ZlQ9g+0978BayngGgL1QKehk61EtlZ0Y2Mg==}
+    engines: {node: '>= 17.0.0'}
+    hasBin: true
+
   figures@1.7.0:
     resolution: {integrity: sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==}
     engines: {node: '>=0.10.0'}
@@ -29939,6 +30428,10 @@ packages:
   find-my-way@9.6.0:
     resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
     engines: {node: '>=20'}
+
+  find-process@2.1.1:
+    resolution: {integrity: sha512-SrQDx3QhlmHM90iqn9rdjCQcw/T+WlpOkHFsjoRgB+zTpDfltNA1VSNYeYELwhUTJy12UFxqjWhmhOrJc+o4sA==}
+    hasBin: true
 
   find-replace@3.0.0:
     resolution: {integrity: sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==}
@@ -30234,6 +30727,10 @@ packages:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
@@ -30477,6 +30974,10 @@ packages:
     resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
     engines: {node: '>=10.19.0'}
 
+  got@15.1.0:
+    resolution: {integrity: sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==}
+    engines: {node: '>=22'}
+
   gql.tada@1.9.2:
     resolution: {integrity: sha512-QxRHVpxtrOVdYXz6oavq0lBM+Zdp0swapLGJcD4SLpXDcsD337BHDFrzqqjfkbepv0sSAiO0LGabu1kI5D5Gyg==}
     hasBin: true
@@ -30713,6 +31214,10 @@ packages:
   hpack.js@2.1.6:
     resolution: {integrity: sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==}
 
+  hpagent@1.2.0:
+    resolution: {integrity: sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==}
+    engines: {node: '>=14'}
+
   html-encoding-sniffer@3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
     engines: {node: '>=12'}
@@ -30843,8 +31348,15 @@ packages:
     resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
     engines: {node: '>=0.8', npm: '>=1.3.7'}
 
+  http-status-codes@2.3.0:
+    resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
+
   http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
+    engines: {node: '>=10.19.0'}
+
+  http2-wrapper@2.2.1:
+    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
     engines: {node: '>=10.19.0'}
 
   https-browserify@1.0.0:
@@ -31076,6 +31588,9 @@ packages:
     resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
     engines: {node: '>= 12'}
 
+  ip@2.0.1:
+    resolution: {integrity: sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -31204,6 +31719,10 @@ packages:
   is-fullwidth-code-point@4.0.0:
     resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
     engines: {node: '>=12'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
 
   is-generator-fn@2.1.0:
     resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
@@ -31866,6 +32385,9 @@ packages:
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
+  jose@6.2.8:
+    resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
+
   jotai-family@1.0.1:
     resolution: {integrity: sha512-Zb/79GNDhC/z82R+6qTTpeKW4l4H6ZCApfF5W8G4SH37E4mhbysU7r8DkP0KX94hWvjB/6lt/97nSr3wB+64Zg==}
     engines: {node: '>=12.20.0'}
@@ -31905,6 +32427,9 @@ packages:
 
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+
+  js-base64@3.8.1:
+    resolution: {integrity: sha512-5xVjhUZlHHeuO2W7w2rDFj/Kl1xLX+HjZxdOQwCsUOifl6UaoH1o1wsbsTMz+r0aeC7gCijvru02j6TfKZWzKg==}
 
   js-cookie@3.0.1:
     resolution: {integrity: sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==}
@@ -31980,6 +32505,10 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
+
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
 
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
@@ -32091,6 +32620,11 @@ packages:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
 
+  jsonpath-plus@10.4.0:
+    resolution: {integrity: sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
@@ -32140,6 +32674,9 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
 
   keyvaluestorage-interface@1.0.0:
     resolution: {integrity: sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==}
@@ -32322,6 +32859,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libphonenumber-js@1.13.10:
+    resolution: {integrity: sha512-xJxrdqvbl2rtn2MaUJrUejz8J7/uZNC0V77oks2LxYrO/+ZtVpRmz+fEQMuu6VusnEB1fmpByiLS1WXecOnAnw==}
 
   libsodium-wrappers@0.8.4:
     resolution: {integrity: sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw==}
@@ -32530,6 +33070,10 @@ packages:
     resolution: {integrity: sha512-P3bA/giMu432bs3gHiKXKOIHlWanCIlRhbhCfgKNgCoyvTvZsdbfkgX1BvThYXhm36cS8pOX3Z5vxXBFZC+NQw==}
     engines: {node: '>=6'}
 
+  listr2@10.2.1:
+    resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
+    engines: {node: '>=22.13.0'}
+
   listr2@6.6.1:
     resolution: {integrity: sha512-+rAXGHh0fkEWdXBmX+L6mmfmXmXvDGEKzkjxO+8mP3+nI/r/CWznVBvsibXdxda9Zz0OW2e2ikphN3OwCT/jSg==}
     engines: {node: '>=16.0.0'}
@@ -32701,6 +33245,10 @@ packages:
     resolution: {integrity: sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
+
   logform@2.6.0:
     resolution: {integrity: sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==}
     engines: {node: '>= 12.0.0'}
@@ -32728,6 +33276,9 @@ packages:
 
   long@5.3.1:
     resolution: {integrity: sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -32767,6 +33318,14 @@ packages:
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
+
+  lowercase-keys@3.0.0:
+    resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lowercase-keys@4.0.1:
+    resolution: {integrity: sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==}
+    engines: {node: '>=20'}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -33530,6 +34089,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  mimic-response@4.0.0:
+    resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -34000,6 +34563,10 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
+  normalize-url@8.1.1:
+    resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
+    engines: {node: '>=14.16'}
+
   normalize-wheel@1.0.1:
     resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
 
@@ -34066,6 +34633,9 @@ packages:
 
   oauth-sign@0.9.0:
     resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+
+  oauth4webapi@3.8.6:
+    resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
 
   ob1@0.81.5:
     resolution: {integrity: sha512-iNpbeXPLmaiT9I5g16gFFFjsF3sGxLpYG2EGP3dfFB4z+l9X60mp/yRzStHhMtuNt8qmf7Ww80nOPQHngHhnIQ==}
@@ -34183,6 +34753,10 @@ packages:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
   only@0.0.2:
     resolution: {integrity: sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==}
 
@@ -34205,6 +34779,9 @@ packages:
   opener@1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
+
+  openid-client@6.8.4:
+    resolution: {integrity: sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==}
 
   optimism@0.18.1:
     resolution: {integrity: sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==}
@@ -34612,8 +35189,15 @@ packages:
   pino-abstract-transport@2.0.0:
     resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
   pino-pretty@13.0.0:
     resolution: {integrity: sha512-cQBBIVG3YajgoUjo1FdKVRX6t9XPxwB9lcNJVD5GCnNM4Y6T12YYx8c6zEejxQsU0wrg9TwmDulcE9LR7qcJqA==}
+    hasBin: true
+
+  pino-pretty@13.1.3:
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
     hasBin: true
 
   pino-std-serializers@7.0.0:
@@ -34625,6 +35209,10 @@ packages:
 
   pino@10.1.0:
     resolution: {integrity: sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w==}
+    hasBin: true
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
 
   pinpoint@1.1.0:
@@ -34657,6 +35245,10 @@ packages:
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
+
+  pkijs@3.4.0:
+    resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
+    engines: {node: '>=16.0.0'}
 
   planck@1.5.0:
     resolution: {integrity: sha512-dlvqJE+FscZgrGUXJ5ybd0o5bvZ5XXyZNbm08xGsXp9WjXeAyWSFT6n9s/1PQcUBo4546fDXA5RMA4wbDyZw6g==}
@@ -35317,6 +35909,14 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
+  protobufjs@8.6.6:
+    resolution: {integrity: sha512-RkLIhE+Tdc2Kpq1F4Uw6OnpAXPca7B+GSDov/GqGCqNBpVyDskQ9yReZfgM+C7xw9AAix873iQZXbBWXj6NzYQ==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@8.7.1:
+    resolution: {integrity: sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==}
+    engines: {node: '>=12.0.0'}
+
   protocols@2.0.1:
     resolution: {integrity: sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==}
 
@@ -35386,11 +35986,16 @@ packages:
     resolution: {integrity: sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==}
     engines: {node: '>=6.0.0'}
 
+  pvutils@1.2.0:
+    resolution: {integrity: sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==}
+    engines: {node: '>=16.0.0'}
+
   q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:
@@ -36149,6 +36754,9 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  real-require@1.0.0:
+    resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
+
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
@@ -36386,6 +36994,10 @@ packages:
   responselike@2.0.1:
     resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
 
+  responselike@4.0.2:
+    resolution: {integrity: sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==}
+    engines: {node: '>=20'}
+
   restore-cursor@2.0.0:
     resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
     engines: {node: '>=4'}
@@ -36397,6 +37009,10 @@ packages:
   restore-cursor@4.0.0:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
 
   ret@0.5.0:
     resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
@@ -36430,6 +37046,9 @@ packages:
 
   rfdc@1.3.1:
     resolution: {integrity: sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
@@ -36663,6 +37282,10 @@ packages:
     resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
     engines: {node: '>=10'}
 
+  selfsigned@5.5.0:
+    resolution: {integrity: sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==}
+    engines: {node: '>=18'}
+
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
 
@@ -36823,6 +37446,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
+    engines: {node: '>= 0.4'}
+
   shell-quote@1.8.0:
     resolution: {integrity: sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==}
 
@@ -36874,6 +37501,9 @@ packages:
   simple-git@3.24.0:
     resolution: {integrity: sha512-QqAKee9Twv+3k8IFOFfPB2hnk6as6Y6ACUpwCtQvRYBAes23Wv3SZlHVobAzqcE8gfsisCvPw3HGW3HYM+VYYw==}
 
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
+
   simple-markdown@0.4.4:
     resolution: {integrity: sha512-ZmlNUGR1KI12sPHeQ7dQY1qM5KfOgFqClNNVO8zQ9Pg6u7gHLCPFGD+VC7MCwpGDMd1uw3Bb2TfFfR8d6bB34A==}
 
@@ -36924,6 +37554,14 @@ packages:
   slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
+
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
 
   sliced@1.0.1:
     resolution: {integrity: sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==}
@@ -37198,6 +37836,10 @@ packages:
     resolution: {integrity: sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==}
     engines: {node: '>= 0.10.0'}
 
+  stream-buffers@3.0.3:
+    resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
+    engines: {node: '>= 0.10.0'}
+
   stream-chain@2.2.5:
     resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
 
@@ -37241,6 +37883,9 @@ packages:
   streamx@2.18.0:
     resolution: {integrity: sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==}
 
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
   strict-event-emitter-types@2.0.0:
     resolution: {integrity: sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==}
 
@@ -37281,6 +37926,10 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
 
   string.prototype.trim@1.2.10:
     resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
@@ -37375,6 +38024,10 @@ packages:
 
   strip-json-comments@5.0.1:
     resolution: {integrity: sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==}
+    engines: {node: '>=14.16'}
+
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
   strip-outer@1.0.1:
@@ -37609,6 +38262,9 @@ packages:
   tar-fs@2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
 
+  tar-fs@3.1.3:
+    resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
+
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
@@ -37634,6 +38290,10 @@ packages:
     resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
     engines: {node: '>=18'}
 
+  tar@7.5.19:
+    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
+    engines: {node: '>=18'}
+
   tarn@3.0.2:
     resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
     engines: {node: '>=8.0.0'}
@@ -37645,6 +38305,9 @@ packages:
   teeny-request@9.0.0:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
     engines: {node: '>=14'}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   telnet-client@1.2.8:
     resolution: {integrity: sha512-W+w4k3QAmULVNhBVT2Fei369kGZCh/TH25M7caJAXW+hLxwoQRuw0di3cX4l0S9fgH3Mvq7u+IFMoBDpEw/eIg==}
@@ -37736,6 +38399,10 @@ packages:
 
   thread-stream@3.0.0:
     resolution: {integrity: sha512-oUIFjxaUT6knhPtWgDMc29zF1FcSl0yXpapkyrQrCGEfYA2HUZXCilUtKyYIv6HkCyqSPAMkY+EG0GbyIrNDQg==}
+
+  thread-stream@4.2.0:
+    resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
+    engines: {node: '>=20'}
 
   three@0.177.0:
     resolution: {integrity: sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==}
@@ -38053,6 +38720,14 @@ packages:
     resolution: {integrity: sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tsyringe-neo@5.1.0:
+    resolution: {integrity: sha512-x6QAckY85YLGE980TIR5Xle3s76nhBNYu0kr6UlLAWiPqt4S6PgbbvNV4cjZlItv3ka8adcGYG2Wy/I2yxcqdg==}
+    engines: {node: '>= 18.0.0'}
+
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
 
   tty-browserify@0.0.0:
     resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}
@@ -38634,6 +39309,10 @@ packages:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
     hasBin: true
 
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
+
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
@@ -38709,6 +39388,10 @@ packages:
 
   validator@13.15.23:
     resolution: {integrity: sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==}
+    engines: {node: '>= 0.10'}
+
+  validator@13.15.35:
+    resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
     engines: {node: '>= 0.10'}
 
   value-or-promise@1.0.12:
@@ -39068,6 +39751,10 @@ packages:
     resolution: {integrity: sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==}
     engines: {node: '>=8.0.0'}
 
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
+
   wrap-ansi@3.0.1:
     resolution: {integrity: sha512-iXR3tDXpbnTpzjKSylUJRkLuOrEC7hwEB221cgn6wtF8wpmz28puFXAEfPT5zrjM3wahygB//VuWEr1vTkDcNQ==}
     engines: {node: '>=4'}
@@ -39083,6 +39770,10 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -39293,6 +39984,11 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yamux-js@0.1.2:
     resolution: {integrity: sha512-bhsPlPZ9xB4Dawyf6nkS58u4F3IvGCaybkEKGnneUeepcI7MPoG3Tt6SaKCU5x/kP2/2w20Qm/GqbpwAM16vYw==}
 
@@ -39307,6 +40003,10 @@ packages:
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yargs-unparser@2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
@@ -39323,6 +40023,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -39349,6 +40053,10 @@ packages:
 
   yoctocolors-cjs@2.1.2:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
+    engines: {node: '>=18'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
 
   yoctocolors@2.1.2:
@@ -46429,6 +47137,11 @@ snapshots:
       '@grpc/proto-loader': 0.7.15
       '@js-sdsl/ordered-map': 4.4.2
 
+  '@grpc/grpc-js@1.12.7':
+    dependencies:
+      '@grpc/proto-loader': 0.7.15
+      '@js-sdsl/ordered-map': 4.4.2
+
   '@grpc/grpc-js@1.13.4':
     dependencies:
       '@grpc/proto-loader': 0.7.15
@@ -46542,6 +47255,24 @@ snapshots:
       - react-native
       - supports-color
 
+  '@hiero-ledger/cryptography@1.20.1':
+    dependencies:
+      '@noble/ciphers': 1.2.1
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.4
+      '@scure/bip32': 1.6.2
+      ansi-regex: 6.2.2
+      ansi-styles: 6.2.3
+      asn1js: 3.0.6
+      bignumber.js: 9.1.2
+      bn.js: 5.2.3
+      debug: 4.4.1
+      forge-light: 1.1.4
+      strip-ansi: 7.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@hiero-ledger/proto@2.25.0(patch_hash=3db17dbc9a7f2fe6248f2f94d98f3ad73afecaf999c190595e95da9c6a0eff29)(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@7.5.4)(strip-ansi@7.1.2)':
     dependencies:
       ansi-regex: 6.2.2
@@ -46550,6 +47281,101 @@ snapshots:
       long: 5.3.1
       protobufjs: 7.5.4
       strip-ansi: 7.1.2
+
+  '@hiero-ledger/proto@2.31.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.6.6)(strip-ansi@7.1.2)':
+    dependencies:
+      ansi-regex: 6.2.2
+      ansi-styles: 6.2.3
+      debug: 4.4.1
+      long: 5.3.1
+      protobufjs: 8.6.6
+      strip-ansi: 7.1.2
+
+  '@hiero-ledger/proto@2.31.0(protobufjs@8.7.1)':
+    dependencies:
+      long: 5.3.1
+      protobufjs: 8.7.1
+
+  '@hiero-ledger/sdk@2.86.2':
+    dependencies:
+      '@grpc/grpc-js': 1.12.7
+      '@hiero-ledger/cryptography': 1.20.1
+      '@hiero-ledger/proto': 2.31.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.6.6)(strip-ansi@7.1.2)
+      ansi-regex: 6.2.2
+      ansi-styles: 6.2.3
+      bignumber.js: 9.1.2
+      bn.js: 5.2.3
+      crypto-js: 4.2.0
+      debug: 4.4.1
+      ethers: 6.15.0
+      js-base64: 3.7.4
+      long: 5.3.1
+      pino: 10.1.0
+      pino-pretty: 13.0.0
+      protobufjs: 8.6.6
+      rfc4648: 1.5.3
+      strip-ansi: 7.1.2
+      utf8: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - expo-crypto
+      - supports-color
+      - utf-8-validate
+
+  '@hiero-ledger/solo@0.83.0(@types/node@24.12.0)':
+    dependencies:
+      '@hiero-ledger/proto': 2.31.0(protobufjs@8.7.1)
+      '@hiero-ledger/sdk': 2.86.2
+      '@inquirer/prompts': 7.10.1(@types/node@24.12.0)
+      '@kubernetes/client-node': 1.4.0
+      '@listr2/prompt-adapter-inquirer': 4.2.4(@inquirer/prompts@7.10.1(@types/node@24.12.0))(@types/node@24.12.0)(listr2@10.2.1)
+      '@peculiar/x509': 2.0.0
+      adm-zip: 0.6.0
+      chalk: 5.6.2
+      class-transformer: 0.5.1
+      class-validator: 0.15.1
+      dot-object: 2.1.5
+      dotenv: 17.4.2
+      elliptic: 6.6.1
+      eol: 0.10.0
+      esm: 3.2.25
+      figlet: 1.11.1
+      find-process: 2.1.1
+      got: 15.1.0
+      http-status-codes: 2.3.0
+      ip: 2.0.1
+      js-base64: 3.8.1
+      listr2: 10.2.1
+      pino: 10.3.1
+      pino-pretty: 13.1.3
+      protobufjs: 8.7.1
+      reflect-metadata: 0.2.2
+      selfsigned: 5.5.0
+      shell-quote: 1.10.0
+      simple-git: 3.36.0
+      source-map-support: 0.5.21
+      stream-buffers: 3.0.3
+      tar: 7.5.19
+      tsyringe-neo: 5.1.0
+      uuid: 14.0.1
+      validator: 13.15.35
+      ws: 8.21.0
+      yaml: 2.9.0
+      yargs: 18.0.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - ansi-regex
+      - ansi-styles
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - debug
+      - encoding
+      - expo-crypto
+      - react-native-b4a
+      - strip-ansi
+      - supports-color
+      - utf-8-validate
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -46562,6 +47388,25 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.2': {}
+
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/checkbox@4.3.2(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/confirm@5.1.21(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
+    optionalDependencies:
+      '@types/node': 24.12.0
 
   '@inquirer/confirm@5.1.7(@types/node@24.12.0)':
     dependencies:
@@ -46583,9 +47428,119 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.0
 
+  '@inquirer/core@10.3.2(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/editor@4.2.23(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/expand@4.0.23(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/external-editor@1.0.3(@types/node@24.12.0)':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.0
+    optionalDependencies:
+      '@types/node': 24.12.0
+
   '@inquirer/figures@1.0.11': {}
 
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@4.3.1(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/number@3.0.23(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/password@4.0.23(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/prompts@7.10.1(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@24.12.0)
+      '@inquirer/confirm': 5.1.21(@types/node@24.12.0)
+      '@inquirer/editor': 4.2.23(@types/node@24.12.0)
+      '@inquirer/expand': 4.0.23(@types/node@24.12.0)
+      '@inquirer/input': 4.3.1(@types/node@24.12.0)
+      '@inquirer/number': 3.0.23(@types/node@24.12.0)
+      '@inquirer/password': 4.0.23(@types/node@24.12.0)
+      '@inquirer/rawlist': 4.1.11(@types/node@24.12.0)
+      '@inquirer/search': 3.2.2(@types/node@24.12.0)
+      '@inquirer/select': 4.4.2(@types/node@24.12.0)
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/rawlist@4.1.11(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/search@3.2.2(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/select@4.4.2(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/type@3.0.10(@types/node@24.12.0)':
+    optionalDependencies:
+      '@types/node': 24.12.0
+
   '@inquirer/type@3.0.5(@types/node@24.12.0)':
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/type@4.0.7(@types/node@24.12.0)':
     optionalDependencies:
       '@types/node': 24.12.0
 
@@ -47338,6 +48293,14 @@ snapshots:
     dependencies:
       lodash: 4.17.21
 
+  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
   '@jsonjoy.com/base64@1.1.2': {}
 
   '@jsonjoy.com/base64@1.1.2(tslib@2.6.2)':
@@ -47570,9 +48533,38 @@ snapshots:
       long: 4.0.0
       protobufjs: 6.11.4
 
+  '@keyv/serialize@1.1.1': {}
+
   '@koa/cors@3.4.3':
     dependencies:
       vary: 1.1.2
+
+  '@kubernetes/client-node@1.4.0':
+    dependencies:
+      '@types/js-yaml': 4.0.9
+      '@types/node': 24.12.0
+      '@types/node-fetch': 2.6.13
+      '@types/stream-buffers': 3.0.8
+      form-data: 4.0.5
+      hpagent: 1.2.0
+      isomorphic-ws: 5.0.0(ws@8.21.0)
+      js-yaml: 4.1.0
+      jsonpath-plus: 10.4.0
+      node-fetch: 2.7.0
+      openid-client: 6.8.4
+      rfc4648: 1.5.4
+      socks-proxy-agent: 8.0.5
+      stream-buffers: 3.0.3
+      tar-fs: 3.1.3
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - encoding
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
@@ -48309,6 +49301,14 @@ snapshots:
     dependencies:
       '@lezer/common': 1.5.1
 
+  '@listr2/prompt-adapter-inquirer@4.2.4(@inquirer/prompts@7.10.1(@types/node@24.12.0))(@types/node@24.12.0)(listr2@10.2.1)':
+    dependencies:
+      '@inquirer/prompts': 7.10.1(@types/node@24.12.0)
+      '@inquirer/type': 4.0.7(@types/node@24.12.0)
+      listr2: 10.2.1
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@lottiefiles/dotlottie-react@0.17.13(react@19.1.4)':
     dependencies:
       '@lottiefiles/dotlottie-web': 0.61.0
@@ -48669,6 +49669,8 @@ snapshots:
       borsh: 1.0.0
     transitivePeerDependencies:
       - encoding
+
+  '@noble/ciphers@1.2.1': {}
 
   '@noble/ciphers@1.3.0': {}
 
@@ -49251,6 +50253,113 @@ snapshots:
     optional: true
 
   '@oxlint/binding-win32-x64-msvc@1.51.0': {}
+
+  '@peculiar/asn1-cms@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.6.2
+
+  '@peculiar/asn1-csr@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.6.2
+
+  '@peculiar/asn1-ecc@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.6.2
+
+  '@peculiar/asn1-pfx@2.8.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.6.2
+
+  '@peculiar/asn1-pkcs8@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.6.2
+
+  '@peculiar/asn1-pkcs9@2.8.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pfx': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.6.2
+
+  '@peculiar/asn1-rsa@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.6.2
+
+  '@peculiar/asn1-schema@2.8.0':
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.6.2
+
+  '@peculiar/asn1-x509-attr@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.6.2
+
+  '@peculiar/asn1-x509@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.6.2
+
+  '@peculiar/utils@2.0.3':
+    dependencies:
+      tslib: 2.6.2
+
+  '@peculiar/x509@1.14.3':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-csr': 2.8.0
+      '@peculiar/asn1-ecc': 2.8.0
+      '@peculiar/asn1-pkcs9': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.6.2
+      tsyringe: 4.10.0
+
+  '@peculiar/x509@2.0.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-csr': 2.8.0
+      '@peculiar/asn1-ecc': 2.8.0
+      '@peculiar/asn1-pkcs9': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      pvtsutils: 1.3.6
+      tslib: 2.6.2
+      tsyringe: 4.10.0
 
   '@pinojs/redact@0.4.0': {}
 
@@ -52208,6 +53317,8 @@ snapshots:
 
   '@scure/base@1.1.6': {}
 
+  '@scure/base@1.2.4': {}
+
   '@scure/base@1.2.6': {}
 
   '@scure/base@2.0.0': {}
@@ -52217,6 +53328,12 @@ snapshots:
       '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.6
+
+  '@scure/bip32@1.6.2':
+    dependencies:
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/base': 1.2.6
 
   '@scure/bip32@1.7.0':
     dependencies:
@@ -52386,6 +53503,12 @@ snapshots:
 
   '@sideway/pinpoint@2.0.0': {}
 
+  '@simple-git/args-pathspec@1.0.3': {}
+
+  '@simple-git/argv-parser@1.1.1':
+    dependencies:
+      '@simple-git/args-pathspec': 1.0.3
+
   '@simple-libs/stream-utils@2.0.0': {}
 
   '@sinclair/typebox@0.24.51': {}
@@ -52395,6 +53518,8 @@ snapshots:
   '@sinclair/typebox@0.34.41': {}
 
   '@sindresorhus/is@4.6.0': {}
+
+  '@sindresorhus/is@8.1.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -55502,6 +56627,8 @@ snapshots:
 
   '@types/http-cache-semantics@4.0.4': {}
 
+  '@types/http-cache-semantics@4.2.0': {}
+
   '@types/http-errors@2.0.4': {}
 
   '@types/http-proxy@1.17.17':
@@ -55531,6 +56658,8 @@ snapshots:
     dependencies:
       expect: 30.2.0
       pretty-format: 30.2.0
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/jsdom@21.1.7':
     dependencies:
@@ -55592,6 +56721,11 @@ snapshots:
   '@types/ms@0.7.34': {}
 
   '@types/node-fetch@2.6.11':
+    dependencies:
+      '@types/node': 24.12.0
+      form-data: 4.0.5
+
+  '@types/node-fetch@2.6.13':
     dependencies:
       '@types/node': 24.12.0
       form-data: 4.0.5
@@ -55793,6 +56927,10 @@ snapshots:
 
   '@types/statuses@2.0.5': {}
 
+  '@types/stream-buffers@3.0.8':
+    dependencies:
+      '@types/node': 24.12.0
+
   '@types/stream-chain@2.0.4':
     dependencies:
       '@types/node': 24.12.0
@@ -55846,6 +56984,8 @@ snapshots:
   '@types/uuid@8.3.4': {}
 
   '@types/uuid@9.0.8': {}
+
+  '@types/validator@13.15.10': {}
 
   '@types/verror@1.10.10':
     optional: true
@@ -57260,6 +58400,8 @@ snapshots:
 
   address@1.2.2: {}
 
+  adm-zip@0.6.0: {}
+
   aes-js@3.1.2: {}
 
   aes-js@4.0.0-beta.5: {}
@@ -57387,6 +58529,10 @@ snapshots:
   ansi-escapes@5.0.0:
     dependencies:
       type-fest: 1.4.0
+
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
 
   ansi-fragments@0.2.1:
     dependencies:
@@ -57606,6 +58752,12 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.2.0
+      tslib: 2.6.2
+
   asn1js@3.0.6:
     dependencies:
       pvtsutils: 1.3.6
@@ -57745,6 +58897,9 @@ snapshots:
       proxy-from-env: 1.1.0
 
   b4a@1.6.6: {}
+
+  b4a@1.8.1:
+    optional: true
 
   babel-jest@29.7.0:
     dependencies:
@@ -58194,6 +59349,40 @@ snapshots:
   bare-events@2.4.2:
     optional: true
 
+  bare-events@2.9.1:
+    optional: true
+
+  bare-fs@4.8.0:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.1.1
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.4.7
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
+  bare-path@3.1.1:
+    optional: true
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
+    optional: true
+
+  bare-url@2.4.7:
+    dependencies:
+      bare-path: 3.1.1
+    optional: true
+
   base-64@0.1.0: {}
 
   base-x@2.0.6:
@@ -58403,6 +59592,8 @@ snapshots:
   bn.js@5.2.1: {}
 
   bn.js@5.2.2: {}
+
+  bn.js@5.2.3: {}
 
   body-parser@1.20.3:
     dependencies:
@@ -58770,11 +59961,15 @@ snapshots:
       mv: 2.1.1
       safe-json-stringify: 1.2.0
 
+  byte-counter@0.1.0: {}
+
   byte-size@6.2.0: {}
 
   bytes@3.0.0: {}
 
   bytes@3.1.2: {}
+
+  bytestreamjs@2.0.1: {}
 
   c32check@1.1.3:
     dependencies:
@@ -58840,6 +60035,18 @@ snapshots:
       ylru: 1.4.0
 
   cacheable-lookup@5.0.4: {}
+
+  cacheable-lookup@7.0.0: {}
+
+  cacheable-request@13.0.19:
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      get-stream: 9.0.1
+      http-cache-semantics: 4.2.0
+      keyv: 5.6.0
+      mimic-response: 4.0.0
+      normalize-url: 8.1.1
+      responselike: 4.0.2
 
   cacheable-request@7.0.4:
     dependencies:
@@ -59041,6 +60248,8 @@ snapshots:
 
   chardet@0.7.0: {}
 
+  chardet@2.2.0: {}
+
   charenc@0.0.2: {}
 
   chart.js@2.9.4:
@@ -59109,6 +60318,8 @@ snapshots:
 
   chromium-pickle-js@0.2.0: {}
 
+  chunk-data@0.1.0: {}
+
   ci-info@2.0.0: {}
 
   ci-info@3.9.0: {}
@@ -59121,6 +60332,14 @@ snapshots:
       safe-buffer: 5.2.1
 
   cjs-module-lexer@2.2.0: {}
+
+  class-transformer@0.5.1: {}
+
+  class-validator@0.15.1:
+    dependencies:
+      '@types/validator': 13.15.10
+      libphonenumber-js: 1.13.10
+      validator: 13.15.35
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -59145,6 +60364,10 @@ snapshots:
   cli-cursor@4.0.0:
     dependencies:
       restore-cursor: 4.0.0
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
 
   cli-highlight@2.1.11:
     dependencies:
@@ -59180,6 +60403,11 @@ snapshots:
       slice-ansi: 5.0.0
       string-width: 7.2.0
 
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.2
+
   cli-width@2.2.1: {}
 
   cli-width@3.0.0: {}
@@ -59213,6 +60441,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+      wrap-ansi: 9.0.2
 
   clone-deep@4.0.1:
     dependencies:
@@ -59366,6 +60600,8 @@ snapshots:
 
   commander@14.0.2: {}
 
+  commander@14.0.3: {}
+
   commander@2.13.0: {}
 
   commander@2.20.3: {}
@@ -59373,6 +60609,8 @@ snapshots:
   commander@4.1.1: {}
 
   commander@5.1.0: {}
+
+  commander@6.2.1: {}
 
   commander@7.2.0: {}
 
@@ -60272,6 +61510,10 @@ snapshots:
 
   decode-uri-component@0.2.2: {}
 
+  decompress-response@10.0.0:
+    dependencies:
+      mimic-response: 4.0.0
+
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -60742,6 +61984,11 @@ snapshots:
       no-case: 3.0.4
       tslib: 2.6.2
 
+  dot-object@2.1.5:
+    dependencies:
+      commander: 6.2.1
+      glob: 7.2.3
+
   dot-prop@10.1.0:
     dependencies:
       type-fest: 5.7.0
@@ -60765,6 +62012,8 @@ snapshots:
   dotenv@16.4.5: {}
 
   dotenv@16.4.7: {}
+
+  dotenv@17.4.2: {}
 
   dotenv@8.6.0: {}
 
@@ -61035,6 +62284,10 @@ snapshots:
   env-paths@3.0.0: {}
 
   envinfo@7.21.0: {}
+
+  environment@1.1.0: {}
+
+  eol@0.10.0: {}
 
   eol@0.9.1: {}
 
@@ -61418,9 +62671,18 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  eventemitter3@5.0.4: {}
+
   eventid@2.0.1:
     dependencies:
       uuid: 8.3.2
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+    optional: true
 
   events@1.1.1: {}
 
@@ -61956,6 +63218,8 @@ snapshots:
 
   fast-copy@3.0.2: {}
 
+  fast-copy@4.0.4: {}
+
   fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
@@ -62103,6 +63367,10 @@ snapshots:
       set-cookie-parser: 2.7.2
       tough-cookie: 6.0.1
 
+  figlet@1.11.1:
+    dependencies:
+      commander: 14.0.2
+
   figures@1.7.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -62217,6 +63485,12 @@ snapshots:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2
       safe-regex2: 5.1.1
+
+  find-process@2.1.1:
+    dependencies:
+      chalk: 4.1.2
+      commander: 14.0.3
+      loglevel: 1.9.2
 
   find-replace@3.0.0:
     dependencies:
@@ -62589,6 +63863,8 @@ snapshots:
 
   get-east-asian-width@1.3.0: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-func-name@2.0.2: {}
 
   get-intrinsic@1.3.0:
@@ -62923,6 +64199,21 @@ snapshots:
       p-cancelable: 2.1.1
       responselike: 2.0.1
 
+  got@15.1.0:
+    dependencies:
+      '@sindresorhus/is': 8.1.0
+      byte-counter: 0.1.0
+      cacheable-lookup: 7.0.0
+      cacheable-request: 13.0.19
+      chunk-data: 0.1.0
+      decompress-response: 10.0.0
+      http2-wrapper: 2.2.1
+      keyv: 5.6.0
+      lowercase-keys: 4.0.1
+      responselike: 4.0.2
+      type-fest: 5.7.0
+      uint8array-extras: 1.5.0
+
   gql.tada@1.9.2(@typescript/typescript6@6.0.2)(graphql@16.13.2):
     dependencies:
       '@0no-co/graphql.web': 1.0.11(graphql@16.13.2)
@@ -63205,6 +64496,8 @@ snapshots:
       readable-stream: 2.3.8
       wbuf: 1.7.3
 
+  hpagent@1.2.0: {}
+
   html-encoding-sniffer@3.0.0:
     dependencies:
       whatwg-encoding: 2.0.0
@@ -63401,7 +64694,14 @@ snapshots:
       jsprim: 1.4.2
       sshpk: 1.18.0
 
+  http-status-codes@2.3.0: {}
+
   http2-wrapper@1.0.3:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
+
+  http2-wrapper@2.2.1:
     dependencies:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
@@ -63638,6 +64938,8 @@ snapshots:
 
   ip-address@10.0.1: {}
 
+  ip@2.0.1: {}
+
   ipaddr.js@1.9.1: {}
 
   ipaddr.js@2.1.0: {}
@@ -63747,6 +65049,10 @@ snapshots:
   is-fullwidth-code-point@3.0.0: {}
 
   is-fullwidth-code-point@4.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
 
   is-generator-fn@2.1.0: {}
 
@@ -65063,6 +66369,8 @@ snapshots:
 
   jose@5.10.0: {}
 
+  jose@6.2.8: {}
+
   jotai-family@1.0.1(jotai@2.17.0(@types/react@19.0.14)(react@19.1.4)):
     dependencies:
       jotai: 2.17.0(@types/react@19.0.14)(react@19.1.4)
@@ -65087,6 +66395,8 @@ snapshots:
   js-base64@3.7.7: {}
 
   js-base64@3.7.8: {}
+
+  js-base64@3.8.1: {}
 
   js-cookie@3.0.1: {}
 
@@ -65227,6 +66537,8 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  jsep@1.4.0: {}
+
   jsesc@3.0.2: {}
 
   jsesc@3.1.0: {}
@@ -65315,6 +66627,12 @@ snapshots:
 
   jsonparse@1.3.1: {}
 
+  jsonpath-plus@10.4.0:
+    dependencies:
+      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
+      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
+      jsep: 1.4.0
+
   jsonpointer@5.0.1: {}
 
   jsonwebtoken@9.0.3:
@@ -65382,6 +66700,10 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
 
   keyvaluestorage-interface@1.0.0: {}
 
@@ -65628,6 +66950,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  libphonenumber-js@1.13.10: {}
+
   libsodium-wrappers@0.8.4:
     dependencies:
       libsodium: 0.8.4
@@ -65808,6 +67132,14 @@ snapshots:
       cli-cursor: 2.1.0
       date-fns: 2.30.0
       figures: 2.0.0
+
+  listr2@10.2.1:
+    dependencies:
+      cli-truncate: 5.2.0
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 10.0.0
 
   listr2@6.6.1:
     dependencies:
@@ -65990,6 +67322,14 @@ snapshots:
       strip-ansi: 7.1.2
       wrap-ansi: 8.1.0
 
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.1.2
+      wrap-ansi: 9.0.2
+
   logform@2.6.0:
     dependencies:
       '@colors/colors': 1.6.0
@@ -66024,6 +67364,8 @@ snapshots:
 
   long@5.3.1: {}
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -66050,6 +67392,10 @@ snapshots:
       tslib: 2.6.2
 
   lowercase-keys@2.0.0: {}
+
+  lowercase-keys@3.0.0: {}
+
+  lowercase-keys@4.0.1: {}
 
   lru-cache@10.4.3: {}
 
@@ -67547,6 +68893,8 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  mimic-response@4.0.0: {}
+
   min-indent@1.0.1: {}
 
   mina-signer@4.0.0:
@@ -68031,6 +69379,8 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
+  normalize-url@8.1.1: {}
+
   normalize-wheel@1.0.1: {}
 
   npm-package-arg@11.0.3:
@@ -68165,6 +69515,8 @@ snapshots:
 
   oauth-sign@0.9.0: {}
 
+  oauth4webapi@3.8.6: {}
+
   ob1@0.81.5:
     dependencies:
       flow-enums-runtime: 0.0.6
@@ -68283,6 +69635,10 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   only@0.0.2: {}
 
   open@10.2.0:
@@ -68308,6 +69664,11 @@ snapshots:
       is-wsl: 2.2.0
 
   opener@1.5.2: {}
+
+  openid-client@6.8.4:
+    dependencies:
+      jose: 6.2.8
+      oauth4webapi: 3.8.6
 
   optimism@0.18.1:
     dependencies:
@@ -68796,6 +70157,10 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
   pino-pretty@13.0.0:
     dependencies:
       colorette: 2.0.20
@@ -68811,6 +70176,22 @@ snapshots:
       secure-json-parse: 2.7.0
       sonic-boom: 4.0.1
       strip-json-comments: 3.1.1
+
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.4
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.0
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.0.1
+      strip-json-comments: 5.0.3
 
   pino-std-serializers@7.0.0: {}
 
@@ -68842,6 +70223,20 @@ snapshots:
       sonic-boom: 4.0.1
       thread-stream: 3.0.0
 
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.0.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.4.3
+      sonic-boom: 4.0.1
+      thread-stream: 4.2.0
+
   pinpoint@1.1.0: {}
 
   pirates@3.0.2:
@@ -68869,6 +70264,15 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  pkijs@3.4.0:
+    dependencies:
+      '@noble/hashes': 1.4.0
+      asn1js: 3.0.6
+      bytestreamjs: 2.0.1
+      pvtsutils: 1.3.6
+      pvutils: 1.1.3
+      tslib: 2.6.2
 
   planck@1.5.0:
     optional: true
@@ -69623,6 +71027,14 @@ snapshots:
       '@types/node': 24.12.0
       long: 5.3.1
 
+  protobufjs@8.6.6:
+    dependencies:
+      long: 5.3.2
+
+  protobufjs@8.7.1:
+    dependencies:
+      long: 5.3.2
+
   protocols@2.0.1: {}
 
   proxy-addr@2.0.7:
@@ -69700,6 +71112,8 @@ snapshots:
       tslib: 2.6.2
 
   pvutils@1.1.3: {}
+
+  pvutils@1.2.0: {}
 
   q@1.5.1: {}
 
@@ -70871,6 +72285,8 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  real-require@1.0.0: {}
+
   recast@0.23.11:
     dependencies:
       ast-types: 0.16.1
@@ -71160,6 +72576,10 @@ snapshots:
     dependencies:
       lowercase-keys: 2.0.0
 
+  responselike@4.0.2:
+    dependencies:
+      lowercase-keys: 3.0.0
+
   restore-cursor@2.0.0:
     dependencies:
       onetime: 2.0.1
@@ -71174,6 +72594,11 @@ snapshots:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
 
   ret@0.5.0: {}
 
@@ -71204,6 +72629,8 @@ snapshots:
   rfc4648@1.5.4: {}
 
   rfdc@1.3.1: {}
+
+  rfdc@1.4.1: {}
 
   rimraf@2.4.5:
     dependencies:
@@ -71458,6 +72885,11 @@ snapshots:
       '@types/node-forge': 1.3.11
       node-forge: 1.4.0
 
+  selfsigned@5.5.0:
+    dependencies:
+      '@peculiar/x509': 1.14.3
+      pkijs: 3.4.0
+
   semver-compare@1.0.0:
     optional: true
 
@@ -71694,6 +73126,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.10.0: {}
+
   shell-quote@1.8.0: {}
 
   shell-quote@1.8.4: {}
@@ -71760,6 +73194,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  simple-git@3.36.0:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   simple-markdown@0.4.4: {}
 
   simple-plist@1.3.1:
@@ -71815,6 +73259,16 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
+
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   sliced@1.0.1: {}
 
@@ -72341,6 +73795,8 @@ snapshots:
 
   stream-buffers@2.2.0: {}
 
+  stream-buffers@3.0.3: {}
+
   stream-chain@2.2.5: {}
 
   stream-demux@10.0.1:
@@ -72402,6 +73858,15 @@ snapshots:
     optionalDependencies:
       bare-events: 2.4.2
 
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.1.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+    optional: true
+
   strict-event-emitter-types@2.0.0: {}
 
   strict-event-emitter@0.5.1: {}
@@ -72444,6 +73909,11 @@ snapshots:
     dependencies:
       emoji-regex: 10.4.0
       get-east-asian-width: 1.3.0
+      strip-ansi: 7.1.2
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
       strip-ansi: 7.1.2
 
   string.prototype.trim@1.2.10:
@@ -72535,6 +74005,8 @@ snapshots:
   strip-json-comments@3.1.1: {}
 
   strip-json-comments@5.0.1: {}
+
+  strip-json-comments@5.0.3: {}
 
   strip-outer@1.0.1:
     dependencies:
@@ -72844,6 +74316,18 @@ snapshots:
       pump: 3.0.0
       tar-stream: 2.2.0
 
+  tar-fs@3.1.3:
+    dependencies:
+      pump: 3.0.0
+      tar-stream: 3.1.7
+    optionalDependencies:
+      bare-fs: 4.8.0
+      bare-path: 3.1.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -72892,6 +74376,14 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
+  tar@7.5.19:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   tarn@3.0.2: {}
 
   teeny-request@10.1.0:
@@ -72913,6 +74405,13 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+    optional: true
 
   telnet-client@1.2.8:
     dependencies:
@@ -73017,6 +74516,10 @@ snapshots:
   thread-stream@3.0.0:
     dependencies:
       real-require: 0.2.0
+
+  thread-stream@4.2.0:
+    dependencies:
+      real-require: 1.0.0
 
   three@0.177.0:
     optional: true
@@ -73442,6 +74945,14 @@ snapshots:
       get-tsconfig: 4.7.5
     optionalDependencies:
       fsevents: 2.3.3
+
+  tsyringe-neo@5.1.0:
+    dependencies:
+      tslib: 2.6.2
+
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 2.6.2
 
   tty-browserify@0.0.0: {}
 
@@ -73998,6 +75509,8 @@ snapshots:
 
   uuid@13.0.0: {}
 
+  uuid@14.0.1: {}
+
   uuid@3.4.0: {}
 
   uuid@7.0.3: {}
@@ -74054,6 +75567,8 @@ snapshots:
   validate.io-number@1.0.3: {}
 
   validator@13.15.23: {}
+
+  validator@13.15.35: {}
 
   value-or-promise@1.0.12: {}
 
@@ -74590,6 +76105,12 @@ snapshots:
       reduce-flatten: 2.0.0
       typical: 5.2.0
 
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.2
+      strip-ansi: 7.1.2
+
   wrap-ansi@3.0.1:
     dependencies:
       string-width: 2.1.1
@@ -74611,6 +76132,12 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
+      strip-ansi: 7.1.2
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
@@ -74750,6 +76277,8 @@ snapshots:
 
   yaml@2.8.3: {}
 
+  yaml@2.9.0: {}
+
   yamux-js@0.1.2: {}
 
   yargs-parser@18.1.3:
@@ -74760,6 +76289,8 @@ snapshots:
   yargs-parser@20.2.9: {}
 
   yargs-parser@21.1.1: {}
+
+  yargs-parser@22.0.0: {}
 
   yargs-unparser@2.0.0:
     dependencies:
@@ -74802,6 +76333,15 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
+
   yauzl@2.10.0:
     dependencies:
       buffer-crc32: 0.2.13
@@ -74820,6 +76360,8 @@ snapshots:
       yoctocolors: 2.1.2
 
   yoctocolors-cjs@2.1.2: {}
+
+  yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
 


### PR DESCRIPTION
### 🪜 Stack

Stacked PRs. Merge in order, 1 first — each one targets the branch above it.

1. #33 `feat(ledger-wallet-framework): add family bridge hooks`
2. #34 `feat(generic-coin-framework): add token-associate mode and family hooks`
3. #35 `feat(hedera): migrate to the generic coin framework`
4. #36 `refactor(hedera): rewire the desktop UI onto GenericTransaction`
5. #37 `refactor(hedera): rewire the mobile UI onto GenericTransaction`
6. #38 `test(coin-tester-hedera): add end-to-end coin-tester for hedera`  ← this PR

---

### 📝 Description

Last PR of the Hedera coin-module migration stack. It adds
`libs/coin-tester-modules/coin-tester-hedera`: end-to-end scenarios that run
sync → craft → status → sign → broadcast → re-sync → assert against a real local
Hedera network (Hiero Solo 0.83), signing with a software Ed25519 key. No
Speculos, no device.

Scenarios, each on its own account funded from the genesis operator:
1. Native HBAR — plain send, send with memo, send to a never-funded alias
   (auto-account-creation), send max.
2. HTS association and transfer — associate a locally minted token, transfer,
   send max.
3. Delegate and undelegate against Solo's consensus node.
4. Two HTS tokens through auto-association, then an HBAR send that must leave
   both sub-accounts untouched.
5. ERC20 transfer against a deployed `LedgerLiveTestToken`.

`src/negativeCases.ts` asserts on `getTransactionStatus` without broadcasting:
insufficient balance, malformed recipient, transfer to an unassociated
recipient, and over-balance HTS and ERC20 transfers.

Also in this PR:
- `src/hgraphFake.ts` — a mirror-node-fed hgraph double, with its own tests.
- `src/solo.ts` — Solo cluster lifecycle.
- `pnpm coin:tester:hedera start` script.
- `hedera` added to `COIN_TESTER_CURRENCIES` in `test-coin-tester.yml`.

**Please check:** this PR also changes the coin-tester job's `runs-on` from
`public-ledgerhq-shared-small` to `ledger-live-linux-8CPU-32RAM`, for every
chain in the matrix, not only Hedera. A Solo run peaks near 4 GB RAM and needs
the larger runner. Tell me if you want that scoped to the Hedera matrix entry
instead.

Known limits are written in `libs/coin-tester-modules/coin-tester-hedera/README.md`:
`ClaimRewards` is out of scope (Solo never pays rewards out), and the ERC20
scenario needs a Kubernetes host to have ever run.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-34359
- **ADR** (if any): —
