### PR TITLE
fix(llm): render casper device confirmation amount and fee (LIVE-36803)

### DIFF
--- a/.changeset/casper-device-confirm-amount-fee-visible.md
+++ b/.changeset/casper-device-confirm-amount-fee-visible.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the Casper device confirmation step where the Fee and Amount values were blank: they are now rendered inside a Text node via `DataRowUnitValue` instead of being passed as a raw element to `TextValueField`.

--- a/apps/ledger-live-mobile/src/families/casper/TransactionConfirmFields.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/TransactionConfirmFields.tsx
@@ -1,12 +1,12 @@
 import invariant from "invariant";
 import React from "react";
+import BigNumber from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
 import type { DeviceTransactionField } from "@ledgerhq/live-common/transaction/index";
 import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/casper/types";
 import { ExtraDeviceTransactionField } from "@ledgerhq/coin-casper/deviceTransactionConfig";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
-import { TextValueField } from "~/components/ValidateOnDeviceDataRow";
-import CurrencyUnitValue from "~/components/CurrencyUnitValue";
+import { DataRowUnitValue } from "~/components/ValidateOnDeviceDataRow";
 
 interface FieldProps {
   account: Account;
@@ -20,15 +20,10 @@ function CasperExtendedAmountField({ account, field, transaction }: FieldProps) 
   invariant(transaction.family === "casper", "casper transaction");
 
   return (
-    <TextValueField
+    <DataRowUnitValue
       label={field.label}
-      value={
-        <CurrencyUnitValue
-          unit={currency.units[1]}
-          value={(field as ExtraDeviceTransactionField).value}
-          disableRounding
-        />
-      }
+      unit={currency.units[1]}
+      value={new BigNumber((field as ExtraDeviceTransactionField).value)}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/families/casper/__tests__/TransactionConfirmFields.test.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/__tests__/TransactionConfirmFields.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { render, screen } from "@tests/test-renderer";
+import type { Account } from "@ledgerhq/types-live";
+import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/casper/types";
+import TransactionConfirmFields from "../TransactionConfirmFields";
+
+const CasperExtendedAmountField = TransactionConfirmFields.fieldComponents["casper.extendedAmount"];
+
+const account = {
+  type: "Account",
+  id: "js:2:casper:0202:casper",
+  currency: {
+    type: "CryptoCurrency",
+    id: "casper",
+    family: "casper",
+    name: "Casper",
+    ticker: "CSPR",
+    units: [
+      { name: "CSPR", code: "CSPR", magnitude: 9 },
+      { name: "motes", code: "motes", magnitude: 0 },
+    ],
+  },
+} as unknown as Account;
+
+const transaction = {
+  family: "casper",
+  amount: new BigNumber(500),
+  fees: new BigNumber(100),
+  recipient: "",
+  useAllAmount: false,
+} as Transaction;
+
+const status = {} as TransactionStatus;
+
+describe("casper TransactionConfirmFields", () => {
+  it("renders the extended amount inside a Text node so the value is visible", () => {
+    render(
+      <CasperExtendedAmountField
+        account={account}
+        transaction={transaction}
+        status={status}
+        field={{ type: "casper.extendedAmount", label: "Amount", value: new BigNumber(500) }}
+      />,
+    );
+
+    expect(screen.getByText("Amount")).toBeOnTheScreen();
+    expect(screen.getByText("500 motes")).toBeOnTheScreen();
+  });
+});


### PR DESCRIPTION
Fee and Amount rendered blank because the value was passed to TextValueField as an element, ending up outside any <Text> node. Use DataRowUnitValue instead.

<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
